### PR TITLE
Use appropriate RTS options

### DIFF
--- a/explorer-api/cardano-explorer-api.cabal
+++ b/explorer-api/cardano-explorer-api.cabal
@@ -129,6 +129,10 @@ executable cardano-explorer-api
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
 
+                        -threaded
+                        -rtsopts
+                        "-with-rtsopts=-T -I0"
+
   -- other-modules:
 
   build-depends:        base                            >= 4.12         && < 4.13

--- a/submit-api/cardano-submit-api.cabal
+++ b/submit-api/cardano-submit-api.cabal
@@ -35,6 +35,10 @@ library
                         -Wno-all-missed-specialisations
                         -Wno-missing-import-lists
 
+                        -threaded
+                        -rtsopts
+                        "-with-rtsopts=-T -I0"
+
   exposed-modules:      Cardano.TxSubmit
 
   other-modules:        Cardano.TxSubmit.Config


### PR DESCRIPTION
Servers must use the threaded runtime system. Many things we use depend on this.

Also allow +RTS options at runtime.

Also disable idle GC, and enable RTS stats collection (for EKG monitoring).