### PR TITLE
Docker: Improve node IPC volume mount

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,3 @@
+postgres_db
+postgres_password
+postgres_user

--- a/default.nix
+++ b/default.nix
@@ -29,9 +29,8 @@ let
   #};
 
   dockerImages = let
-    stateDir = "/data";
     defaultConfig = rec {
-      services.cardano-submit-api.socketPath = stateDir + "/node.socket";
+      services.cardano-submit-api.socketPath = "/node-ipc/node.socket";
     };
     customConfig' = lib.mkMerge [ defaultConfig customConfig ];
   in pkgs.callPackage ./nix/docker.nix {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     environment:
       - NETWORK=${NETWORK}
     volumes:
-      - cardano-node:/data
+      - node-db:/data/db
+      - node-ipc:/ipc
 
   cardano-db-sync:
     image: inputoutput/cardano-db-sync:master
@@ -37,7 +38,7 @@ services:
       - postgres_user
       - postgres_db
     volumes:
-      - cardano-node:/data
+      - node-ipc:/node-ipc
     restart: on-failure
 
   cardano-explorer-api:
@@ -63,7 +64,7 @@ services:
     depends_on:
       - cardano-node
     volumes:
-      - cardano-node:/data
+      - node-ipc:/node-ipc
     ports:
       - 8101:8101
     restart: on-failure
@@ -75,9 +76,8 @@ secrets:
     file: ./config/postgres_password
   postgres_user:
     file: ./config/postgres_user
-  pgpass:
-    file: ./config/pgpass
 
 volumes:
   postgres:
-  cardano-node:
+  node-db:
+  node-ipc:


### PR DESCRIPTION
Align with changes presented in https://github.com/input-output-hk/cardano-node/pull/779/files to enable mounting of the IPC socket into client containers without the node db coming along for the ride. Although this is primarily an upstream fix, I've taken the opportunity to align with the recent change in `cardano-node` to use the more verbose _configuration_ term so we don't end up with a variation.

# Overview
- [x] changes `data` to `node-ipc` for clarity
- [x] uses `configuration` over `config` to conform with style in `cardano-node`


# Comments
~**WIP** until fully tested with changes to `cardano-node`. Currently an issue to resolve in https://github.com/input-output-hk/cardano-node/pull/779~ 