### PR TITLE
Update dependencies and make required changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,6 +12,18 @@ package cardano-submit-api
   tests: True
   ghc-options: -Wall -Werror -fwarn-redundant-constraints
 
+package cardano-db-sync
+  tests: False
+
+package cardano-shell
+  tests: False
+
+package ouroboros-consensus
+  tests: False
+
+package ouroboros-consensus-cardano
+  tests: False
+
 package ouroboros-consensus-byron
   tests: False
 
@@ -30,15 +42,15 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 5407a064d4462712a5641295e93cf94d906bd897
-  --sha256: 12sxh4pqkxljd67cjiq8y46phxyyhsngczlvz9darfj2p8bx5zqa
+  tag: 5fa05200ea928e37a26f061e02ac44feda234135
+  --sha256: 0plmch4ci8azg1712h9rd04g2nwc5df7if1n5hkg3v52kv3xpdcs
   subdir: cardano-db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 5407a064d4462712a5641295e93cf94d906bd897
-  --sha256: 12sxh4pqkxljd67cjiq8y46phxyyhsngczlvz9darfj2p8bx5zqa
+  tag: 5fa05200ea928e37a26f061e02ac44feda234135
+  --sha256: 0plmch4ci8azg1712h9rd04g2nwc5df7if1n5hkg3v52kv3xpdcs
   subdir: cardano-db-sync
 
 source-repository-package
@@ -51,14 +63,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
-  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
+  tag: 316c854d1d3089f480708ad5cd5ecf8a74423ddd
+  --sha256: 1srbl3jrkmpwypdz0yrx4nmah3qcsr93dp48zx2bamg51c4hcsyj
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
-  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
+  tag: 316c854d1d3089f480708ad5cd5ecf8a74423ddd
+  --sha256: 1srbl3jrkmpwypdz0yrx4nmah3qcsr93dp48zx2bamg51c4hcsyj
   subdir: test
 
 source-repository-package
@@ -70,79 +82,93 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
+  subdir:   plugins/backend-trace-forwarder
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: tracer-transformers
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
-  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
+  tag: c454b6e791ee2fe84508b4d5ed2c4dedafb7dce4
+  --sha256: 01m5jq6gsym3j4v85lv01n6f8480lglrb0n2mv87aqm5ksh4di9y
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
-  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
+  tag: c454b6e791ee2fe84508b4d5ed2c4dedafb7dce4
+  --sha256: 01m5jq6gsym3j4v85lv01n6f8480lglrb0n2mv87aqm5ksh4di9y
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
-  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
+  tag: c454b6e791ee2fe84508b4d5ed2c4dedafb7dce4
+  --sha256: 01m5jq6gsym3j4v85lv01n6f8480lglrb0n2mv87aqm5ksh4di9y
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 1222078176fe74d5ce17f2a8343c6588233a49a3
-  --sha256: 1xnccf7p1979wvqdjnkj8a68k3yy3a9z0gbnbl4pghcv24j2myfm
+  tag: c454b6e791ee2fe84508b4d5ed2c4dedafb7dce4
+  --sha256: 01m5jq6gsym3j4v85lv01n6f8480lglrb0n2mv87aqm5ksh4di9y
   subdir: slotting
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-base
+  tag: c454b6e791ee2fe84508b4d5ed2c4dedafb7dce4
+  --sha256: 01m5jq6gsym3j4v85lv01n6f8480lglrb0n2mv87aqm5ksh4di9y
+  subdir: cardano-crypto-praos
 
 source-repository-package
   type: git
@@ -153,181 +179,209 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
-  subdir: byron/semantics/executable-spec
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
-  subdir: byron/ledger/executable-spec
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: byron/ledger/impl/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: byron/crypto/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: byron/ledger/executable-spec
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: semantics/executable-spec
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: semantics/small-steps-test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
-  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
-  subdir: cardano-ledger
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
-  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
-  subdir: cardano-ledger/test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
-  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
-  subdir: crypto
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
-  --sha256: 1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l
-  subdir: crypto/test
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 6611345670dad971fbd03594a00b5ef8afa4cae6
+  --sha256: 0rhdlf7kz62231127ywbakhsgsxhhkba5gz24dfy7l9r45a1ijkk
+  subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
+  subdir: cardano-client
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: Win32-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-consensus/ouroboros-consensus-test-infra
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-consensus-byronspec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: e71aa72adc7e876cda4ff19b5cc0900167fa9804
-  --sha256: 0a16fd350kvyq4a23y8ma09r5sfs4xsr0gll0ssndd6ygpsd5s4b
+  tag: 11e5609e01f4703870e88b2712e2c14da0338b65
+  --sha256: 10q7n4k1c4yp5vkbwxgvx4ssljiw7q8ai4jn69k3yrmf5sxipawy
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: b5b0a293a890af48070d0ea5df97dd48dc0551e7
-  --sha256: 1dp0lb4cy9yq9k3d55gk0dlmkhpjzfyw9qk9cvcw95q50c5jg58s
+  tag: 8c72fc00cb75b7e7a2c9423ba50c639f6236c88b
+  --sha256: 0h08p1plyxik8wwcws2cvgkvlxlhgg33v3mfj110lzrfiwq4yygs
+  subdir: cardano-api
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: 8c72fc00cb75b7e7a2c9423ba50c639f6236c88b
+  --sha256: 0h08p1plyxik8wwcws2cvgkvlxlhgg33v3mfj110lzrfiwq4yygs
   subdir: cardano-config

--- a/cabal.project
+++ b/cabal.project
@@ -42,15 +42,15 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 5fa05200ea928e37a26f061e02ac44feda234135
-  --sha256: 0plmch4ci8azg1712h9rd04g2nwc5df7if1n5hkg3v52kv3xpdcs
+  tag: 1185967393d5052f3c5af540e1e1f058599019cf
+  --sha256: 0irjm0ji7kdmaa25d9248kcy78a19akz82zvrrxh78r496i0cch2
   subdir: cardano-db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 5fa05200ea928e37a26f061e02ac44feda234135
-  --sha256: 0plmch4ci8azg1712h9rd04g2nwc5df7if1n5hkg3v52kv3xpdcs
+  tag: 1185967393d5052f3c5af540e1e1f058599019cf
+  --sha256: 0irjm0ji7kdmaa25d9248kcy78a19akz82zvrrxh78r496i0cch2
   subdir: cardano-db-sync
 
 source-repository-package

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,6 +24,8 @@ let
     ++ iohkNix.overlays.haskell-nix-extra
     # iohkNix: nix utilities and niv:
     ++ iohkNix.overlays.iohkNix
+    # libsodium fork
+    ++ iohkNix.overlays.crypto
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -30,10 +30,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "cf1e39b3c26d22682a0c6891fd2525e97c2c62aa",
-        "sha256": "0dz6hxb7hq4gwlb56dh8spyb21cyannxvac1sfjjnwmjlxv9ql9y",
+        "rev": "95f7dfdff554223606f6be266c36eabe81cbe800",
+        "sha256": "05ibcw52jg7q66sd0vqj0fv3zlz7mdrfywys9111n4bj9rd9rl1n",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/cf1e39b3c26d22682a0c6891fd2525e97c2c62aa.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/95f7dfdff554223606f6be266c36eabe81cbe800.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-db-sync
-    commit: 5407a064d4462712a5641295e93cf94d906bd897
+    commit: 1185967393d5052f3c5af540e1e1f058599019cf
     subdirs:
       - cardano-db
       - cardano-db-sync

--- a/submit-api/app/cardano-submit-api.hs
+++ b/submit-api/app/cardano-submit-api.hs
@@ -1,62 +1,7 @@
-import           Cardano.TxSubmit (ConfigFile (..), GenesisFile (..), SocketPath (..),
-                    TxSubmitNodeParams (..), TxSubmitPort (..), runTxSubmitWebapi)
+import           Cardano.TxSubmit (opts, runTxSubmitWebapi)
 
-import           Options.Applicative (Parser, ParserInfo, (<**>))
 import qualified Options.Applicative as Opt
 
 main :: IO ()
 main =
   runTxSubmitWebapi =<< Opt.execParser opts
-
--- -------------------------------------------------------------------------------------------------
-
-opts :: ParserInfo TxSubmitNodeParams
-opts =
-  Opt.info (pCommandLine <**> Opt.helper)
-    ( Opt.fullDesc
-    <> Opt.progDesc "Cardano transaction submission webapi."
-    )
-
-pCommandLine :: Parser TxSubmitNodeParams
-pCommandLine =
-  TxSubmitNodeParams
-    <$> pConfigFile
-    <*> pGenesisFile
-    <*> pSocketPath
-    <*> pWebPort
-
-
-pConfigFile :: Parser ConfigFile
-pConfigFile =
-  ConfigFile <$> Opt.strOption
-    ( Opt.long "config"
-    <> Opt.help "Path to the tx-submit webapi config file"
-    <> Opt.completer (Opt.bashCompleter "file")
-    <> Opt.metavar "FILEPATH"
-    )
-
-pGenesisFile :: Parser GenesisFile
-pGenesisFile =
-  GenesisFile <$> Opt.strOption
-    ( Opt.long "genesis-file"
-    <> Opt.help "Path to the genesis JSON file"
-    <> Opt.completer (Opt.bashCompleter "file")
-    <> Opt.metavar "FILEPATH"
-    )
-
-pSocketPath :: Parser SocketPath
-pSocketPath =
-  SocketPath <$> Opt.strOption
-    ( Opt.long "socket-path"
-    <> Opt.help "Path to a cardano-node socket"
-    <> Opt.completer (Opt.bashCompleter "file")
-    <> Opt.metavar "FILEPATH"
-    )
-
-pWebPort :: Parser TxSubmitPort
-pWebPort =
-  TxSubmitPort . read <$> Opt.strOption
-    ( Opt.long "port"
-    <> Opt.help "The port the webapi should listen on"
-    <> Opt.metavar "PORT"
-    )

--- a/submit-api/cardano-submit-api.cabal
+++ b/submit-api/cardano-submit-api.cabal
@@ -45,6 +45,7 @@ library
                       , Cardano.TxSubmit.ErrorRender
                       , Cardano.TxSubmit.Metrics
                       , Cardano.TxSubmit.Node
+                      , Cardano.TxSubmit.Parsers
                       , Cardano.TxSubmit.Tracing.ToObjectOrphans
                       , Cardano.TxSubmit.Tx
                       , Cardano.TxSubmit.Types
@@ -56,13 +57,12 @@ library
                       , async
                       , base16-bytestring
                       , bytestring
+                      , cardano-api
                       , cardano-binary
                       , cardano-crypto-class
                       , cardano-crypto-wrapper
-                      , cardano-db-sync
                       , cardano-prelude
                       , cardano-ledger
-                      , cardano-shell
                       , containers
                       , contra-tracer
                       , cryptonite
@@ -78,6 +78,7 @@ library
                       , monad-logger
                       , mtl
                       , network
+                      , optparse-applicative
                       , ouroboros-consensus
                       , ouroboros-consensus-byron
                       , ouroboros-consensus-cardano

--- a/submit-api/src/Cardano/TxSubmit.hs
+++ b/submit-api/src/Cardano/TxSubmit.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Cardano.TxSubmit
   ( module X
   , runTxSubmitWebapi
@@ -10,15 +12,11 @@ import qualified Cardano.BM.Setup as Logging
 import qualified Cardano.BM.Trace as Logging
 import           Cardano.BM.Trace (Trace, logInfo)
 
-import qualified Cardano.Chain.Genesis as Genesis
-import           Cardano.Crypto (decodeAbstractHash)
-
 import           Cardano.Prelude
-
-import           Cardano.Shell.Lib (GeneralException (ConfigurationError))
 
 import           Cardano.TxSubmit.Config as X
 import           Cardano.TxSubmit.Node as X
+import           Cardano.TxSubmit.Parsers as X
 import           Cardano.TxSubmit.Tx as X
 import           Cardano.TxSubmit.Types as X
 import           Cardano.TxSubmit.Util as X
@@ -32,30 +30,22 @@ import           Data.Text (Text)
 
 runTxSubmitWebapi :: TxSubmitNodeParams -> IO ()
 runTxSubmitWebapi tsnp = do
-  tsnc <- readTxSubmitNodeConfig (unConfigFile $ tspConfigFile tsnp)
-  gc <- readGenesisConfig tsnp tsnc
-  trce <- mkTracer tsnc
-  tsv <- newTxSubmitVar
-  Async.race_
-    (runTxSubmitNode tsv trce gc (tspSocketPath tsnp))
-    (runTxSubmitServer tsv trce (tspWebPort tsnp))
-  logInfo trce "runTxSubmitWebapi: Async.race_ returned"
+    tsnc <- readTxSubmitNodeConfig (unConfigFile $ tspConfigFile tsnp)
+    trce <- mkTracer tsnc
+    tsv <- newTxSubmitVar
+    Async.race_
+      (runTxSubmitNode tsv trce tspProtocol tspNetworkId tspSocketPath)
+      (runTxSubmitServer tsv trce (tspWebPort tsnp))
+    logInfo trce "runTxSubmitWebapi: Async.race_ returned"
+  where
+    TxSubmitNodeParams
+      { tspProtocol
+      , tspNetworkId
+      , tspSocketPath
+      } = tsnp
 
 mkTracer :: TxSubmitNodeConfig -> IO (Trace IO Text)
 mkTracer enc =
   if not (tscEnableLogging enc)
     then pure Logging.nullTracer
     else liftIO $ Logging.setupTrace (Right $ tscLoggingConfig enc) "cardano-tx-submit"
-
-readGenesisConfig :: TxSubmitNodeParams -> TxSubmitNodeConfig -> IO Genesis.Config
-readGenesisConfig enp enc = do
-    genHash <- either (throwIO . ConfigurationError) pure $
-                decodeAbstractHash (unGenesisHash $ tscGenesisHash enc)
-    convert =<< runExceptT (Genesis.mkConfigFromFile (tscRequiresNetworkMagic enc)
-                            (unGenesisFile $ tspGenesisFile enp) genHash)
-  where
-    convert :: Either Genesis.ConfigurationError Genesis.Config -> IO Genesis.Config
-    convert =
-      \case
-        Left err -> panic $ show err
-        Right x -> pure x

--- a/submit-api/src/Cardano/TxSubmit/Parsers.hs
+++ b/submit-api/src/Cardano/TxSubmit/Parsers.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.TxSubmit.Parsers
+  ( opts
+  , pTxSubmitNodeParams
+  , pConfigFile
+  , pNetworkId
+  , pProtocol
+  , pSocketPath
+  , pWebPort
+  ) where
+
+import           Prelude (read)
+import           Cardano.Prelude
+
+import           Options.Applicative (Parser, ParserInfo, (<**>))
+import qualified Options.Applicative as Opt
+
+import           Cardano.Api.Protocol (Protocol (..))
+import           Cardano.Api.Typed (NetworkId (..), NetworkMagic (..))
+
+import           Cardano.Chain.Slotting (EpochSlots (..))
+
+import           Cardano.TxSubmit.Node (ConfigFile (..), SocketPath (..),
+                    TxSubmitNodeParams (..))
+import           Cardano.TxSubmit.Types (TxSubmitPort (..))
+
+import           Ouroboros.Consensus.Cardano (SecurityParam (..))
+
+opts :: ParserInfo TxSubmitNodeParams
+opts =
+  Opt.info (pTxSubmitNodeParams <**> Opt.helper)
+    ( Opt.fullDesc
+    <> Opt.progDesc "Cardano transaction submission web API."
+    )
+
+pTxSubmitNodeParams :: Parser TxSubmitNodeParams
+pTxSubmitNodeParams =
+  TxSubmitNodeParams
+    <$> pConfigFile
+    <*> pProtocol
+    <*> pNetworkId
+    <*> pSocketPath
+    <*> pWebPort
+
+pConfigFile :: Parser ConfigFile
+pConfigFile =
+  ConfigFile <$> Opt.strOption
+    ( Opt.long "config"
+    <> Opt.help "Path to the tx-submit web API configuration file"
+    <> Opt.completer (Opt.bashCompleter "file")
+    <> Opt.metavar "FILEPATH"
+    )
+
+-- TODO: This was ripped from `cardano-cli` because, unfortunately, it's not
+-- exported. Once we export this parser from the appropriate module and update
+-- our `cardano-cli` dependency, we should remove this and import the parser
+-- from there.
+pNetworkId :: Parser NetworkId
+pNetworkId =
+  pMainnet <|> fmap Testnet pTestnetMagic
+ where
+   pMainnet :: Parser NetworkId
+   pMainnet =
+    Opt.flag' Mainnet
+      (  Opt.long "mainnet"
+      <> Opt.help "Use the mainnet magic id."
+      )
+
+   pTestnetMagic :: Parser NetworkMagic
+   pTestnetMagic =
+     NetworkMagic <$>
+       Opt.option Opt.auto
+         (  Opt.long "testnet-magic"
+         <> Opt.metavar "NATURAL"
+         <> Opt.help "Specify a testnet magic id."
+         )
+
+
+-- TODO: This was ripped from `cardano-cli` because, unfortunately, it's not
+-- exported. Once we export this parser from the appropriate module and update
+-- our `cardano-cli` dependency, we should remove this and import the parser
+-- from there.
+pProtocol :: Parser Protocol
+pProtocol =
+    (  Opt.flag' ()
+        (  Opt.long "shelley-mode"
+        <> Opt.help "For talking to a node running in Shelley-only mode (default)."
+        )
+    *> pShelley
+    )
+  <|>
+    (  Opt.flag' ()
+        (  Opt.long "byron-mode"
+        <> Opt.help "For talking to a node running in Byron-only mode."
+        )
+    *> pByron
+    )
+  <|>
+    (  Opt.flag' ()
+        (  Opt.long "cardano-mode"
+        <> Opt.help "For talking to a node running in full Cardano mode."
+        )
+    *> pCardano
+    )
+  <|>
+    -- Default to the Shelley protocol for now, due to the testnet.
+    pure ShelleyProtocol
+  where
+    pByron :: Parser Protocol
+    pByron = ByronProtocol <$> pEpochSlots <*> pSecurityParam
+
+    pShelley :: Parser Protocol
+    pShelley = pure ShelleyProtocol
+
+    pCardano :: Parser Protocol
+    pCardano = CardanoProtocol <$> pEpochSlots <*> pSecurityParam
+
+    pEpochSlots :: Parser EpochSlots
+    pEpochSlots =
+      EpochSlots <$>
+        ( Opt.option Opt.auto
+            (  Opt.long "epoch-slots"
+            <> Opt.metavar "NATURAL"
+            <> Opt.help "The number of slots per epoch (default is 21600)."
+            )
+        <|>
+          -- Default to the mainnet value.
+          pure 21600
+        )
+
+    pSecurityParam :: Parser SecurityParam
+    pSecurityParam =
+      SecurityParam <$>
+        ( Opt.option Opt.auto
+            (  Opt.long "security-param"
+            <> Opt.metavar "NATURAL"
+            <> Opt.help "The security parameter (default is 2160)."
+            )
+        <|>
+          -- Default to the mainnet value.
+          pure 2160
+        )
+
+pSocketPath :: Parser SocketPath
+pSocketPath =
+  SocketPath <$> Opt.strOption
+    ( Opt.long "socket-path"
+    <> Opt.help "Path to a cardano-node socket"
+    <> Opt.completer (Opt.bashCompleter "file")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pWebPort :: Parser TxSubmitPort
+pWebPort =
+  TxSubmitPort . read <$> Opt.strOption
+    ( Opt.long "port"
+    <> Opt.help "The port the web API should listen on"
+    <> Opt.metavar "PORT"
+    )

--- a/submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
+++ b/submit-api/src/Cardano/TxSubmit/Tracing/ToObjectOrphans.hs
@@ -7,7 +7,6 @@
 
 module Cardano.TxSubmit.Tracing.ToObjectOrphans () where
 
-import Cardano.BM.Data.LogItem
 import Cardano.BM.Data.Severity
 import Cardano.BM.Data.Tracer
 import Data.Aeson
@@ -33,16 +32,11 @@ instance HasSeverityAnnotation (WithAddr Socket.SockAddr ErrorPolicyTrace) where
     ErrorPolicyAcceptException {} -> Error
 
 
+instance HasTextFormatter (WithAddr Socket.SockAddr ErrorPolicyTrace) where
+
 -- transform @ErrorPolicyTrace@
 instance Transformable Text IO (WithAddr Socket.SockAddr ErrorPolicyTrace) where
-  trTransformer StructuredLogging verb tr = trStructured verb tr
-  trTransformer TextualRepresentation _verb tr = Tracer $ \s -> do
-    traceWith tr . (mempty,) =<< LogObject
-        <$> pure mempty
-        <*> mkLOMeta (getSeverityAnnotation s) (getPrivacyAnnotation s)
-        <*> pure (LogMessage $ pack $ show s)
-
-  trTransformer UserdefinedFormatting verb tr = trStructured verb tr
+  trTransformer verb tr = trStructured verb tr
 
 instance ToObject (WithAddr Socket.SockAddr ErrorPolicyTrace) where
   toObject _verb (WithAddr addr ev) =

--- a/submit-api/src/Cardano/TxSubmit/Tx.hs
+++ b/submit-api/src/Cardano/TxSubmit/Tx.hs
@@ -21,13 +21,15 @@ import Control.Monad.Class.MonadSTM.Strict
     ( StrictTMVar, atomically, newEmptyTMVarM, putTMVar, takeTMVar )
 import Ouroboros.Consensus.Byron.Ledger
     ( ByronBlock (..), GenTx (..) )
+import Ouroboros.Network.Protocol.LocalTxSubmission.Type
+    ( SubmitResult (..) )
 
 -- The type of 'reject' (determined by ouroboros-network) is currently 'Maybe String'.
 -- Hopefully that will be fixed to make it a concrete type.
 -- See: https://github.com/input-output-hk/ouroboros-network/issues/1335
 data TxSubmitVar = TxSubmitVar
   { txSubmit :: !(StrictTMVar IO (GenTx ByronBlock))
-  , txRespond :: !(StrictTMVar IO (Maybe ApplyMempoolPayloadErr))
+  , txRespond :: !(StrictTMVar IO (SubmitResult ApplyMempoolPayloadErr))
   }
 
 newTxSubmitVar :: IO (TxSubmitVar)
@@ -40,9 +42,12 @@ readTxSubmit tsv =
   atomically $ takeTMVar (txSubmit tsv)
 
 -- | Write the response recieved when tx has been submitted.
-writeTxSubmitResponse :: TxSubmitVar -> (Maybe ApplyMempoolPayloadErr) -> IO ()
-writeTxSubmitResponse tsv merr =
-  atomically $ putTMVar (txRespond tsv) merr
+writeTxSubmitResponse
+  :: TxSubmitVar
+  -> (SubmitResult ApplyMempoolPayloadErr)
+  -> IO ()
+writeTxSubmitResponse tsv submitRes =
+  atomically $ putTMVar (txRespond tsv) submitRes
 
 -- | Submit a tx and wait for the response. This is done as a pair of atomic
 -- operations, to allow the tx to be read in one operation, submmited and then
@@ -54,7 +59,10 @@ submitTx tsv tx =
   case tx of
     ByronTx txid _ -> do
       atomically $ putTMVar (txSubmit tsv) tx
-      maybe (Right txid) (Left . TxSubmitFail) <$> atomically (takeTMVar $ txRespond tsv)
+      submitRes <- atomically (takeTMVar $ txRespond tsv)
+      case submitRes of
+        SubmitSuccess -> pure $ Right txid
+        SubmitFail r -> pure $ Left (TxSubmitFail r)
     ByronDlg {} -> pure $ Left $ TxSubmitBadTx "Delegation"
     ByronUpdateProposal {} -> pure $ Left $ TxSubmitBadTx "Proposal"
     ByronUpdateVote {} -> pure $ Left $ TxSubmitBadTx "UpdateVote"


### PR DESCRIPTION
- Update dependencies such that we can utilize a more recent version of `cardano-api`.
- Utilize `cardano-api` in `Cardano.TxSubmit.Node` as opposed to using the lower-level `ouroboros-network` and `ouroboros-consensus` APIs.
- Remove unnecessary usage of genesis file from `cardano-submit-api`. Instead, accept the required values as CLI args (socket path, network ID, and the protocol).