### PR TITLE
Refactoring query functions to make better use of SqlPersistT.

### DIFF
--- a/explorer-api/app/Explorer/Web/Validate.hs
+++ b/explorer-api/app/Explorer/Web/Validate.hs
@@ -17,7 +17,7 @@ import Database.Persist.Postgresql
 import Database.Persist.Sql
     ( SqlBackend )
 import Explorer.Web.Api.Legacy.Util
-    ( textShow )
+    ( runQuery, textShow )
 import Explorer.Web.Validate.Address
     ( validateAddressSummary, validateRedeemAddressSummary )
 import Explorer.Web.Validate.BlocksTxs
@@ -44,9 +44,9 @@ runValidation count = do
           loop backend (n + 1)
 
 validate :: SqlBackend -> IO ()
-validate backend = do
-  validateRedeemAddressSummary backend
-  validateAddressSummary backend
-  validateGenesisAddressPaging backend
-  validateBlocksTxs backend
-  putStrLn ""
+validate backend = runQuery backend $ do
+  validateRedeemAddressSummary
+  validateAddressSummary
+  validateGenesisAddressPaging
+  validateBlocksTxs
+  liftIO $ putStrLn ""

--- a/explorer-api/app/Explorer/Web/Validate/GenesisAddress.hs
+++ b/explorer-api/app/Explorer/Web/Validate/GenesisAddress.hs
@@ -47,9 +47,9 @@ validateGenesisAddressPaging = do
     page1 <- queryAllGenesisAddresses pageNo pageSize
     page2 <- queryAllGenesisAddresses (nextPageNo pageNo) pageSize
     pure (extractAddresses page1, extractAddresses page2)
-  if length (List.nub $ addr1 ++ addr2) == length addr1 + length addr2
-    then liftIO $ Text.putStrLn $ "  Adjacent pages for Genesis addresses do not overlap: " <> green "ok"
-    else liftIO $ reportIntersectFail addr1 addr2
+  liftIO $ if length (List.nub $ addr1 ++ addr2) == length addr1 + length addr2
+    then Text.putStrLn $ "  Adjacent pages for Genesis addresses do not overlap: " <> green "ok"
+    else reportIntersectFail addr1 addr2
 
 
 extractAddresses :: [CGenesisAddressInfo] -> [CAddress]

--- a/explorer-api/src/Explorer/Web/Api/HttpBridge/AddressBalance.hs
+++ b/explorer-api/src/Explorer/Web/Api/HttpBridge/AddressBalance.hs
@@ -9,8 +9,6 @@ import Cardano.Db
     ( EntityField (..), queryNetworkName, txOutUnspentP )
 import Control.Monad.IO.Class
     ( MonadIO )
-import Control.Monad.Trans.Reader
-    ( ReaderT )
 import Data.ByteString.Char8
     ( ByteString )
 import Data.Text
@@ -20,17 +18,15 @@ import Data.Word
 import Database.Esqueleto
     ( InnerJoin (..), Value (..), from, on, select, val, where_, (==.), (^.) )
 import Database.Persist.Sql
-    ( SqlBackend )
+    ( SqlPersistT )
 import Explorer.Web.Api.Legacy.Util
-    ( bsBase16Encode, decodeTextAddress, runQuery )
+    ( bsBase16Encode, decodeTextAddress )
 import Explorer.Web.ClientTypes
     ( CAddress (..)
     , CAddressBalance (..)
     , CAddressBalanceError (..)
     , CNetwork (..)
     )
-import Servant
-    ( Handler )
 
 -- This endpoint emulates the Rust cardano-http-bridge endpoint:
 --
@@ -48,15 +44,14 @@ import Servant
 
 -- This endpoint always returns a list (which may be empty).
 -- There are a number of potential failures and wyat
-addressBalance
-    :: SqlBackend -> CNetwork -> CAddress
-    -> Handler CAddressBalanceError
-addressBalance backend (CNetwork networkName) (CAddress addrTxt) =
+addressBalance ::
+     MonadIO m => CNetwork -> CAddress -> SqlPersistT m CAddressBalanceError
+addressBalance (CNetwork networkName) (CAddress addrTxt) =
   -- Currently ignore the 'CNetwork' parameter (eg mainnet, testnet etc) as the explorer only
   -- supports a single network and returns a result for whichever network its running on.
   case decodeTextAddress addrTxt of
     Left _ -> pure $ CABError "Invalid address"
-    Right _ -> runQuery backend $ do
+    Right _ -> do
                 mNetName <- queryNetworkName
                 case mNetName of
                   Nothing -> pure $ CABError "Invalid network name"
@@ -66,7 +61,7 @@ addressBalance backend (CNetwork networkName) (CAddress addrTxt) =
 
 -- -------------------------------------------------------------------------------------------------
 
-queryAddressBalance :: MonadIO m => Text -> ReaderT SqlBackend m [CAddressBalance]
+queryAddressBalance :: MonadIO m => Text -> SqlPersistT m [CAddressBalance]
 queryAddressBalance addrTxt = do
     rows <- select . from $ \ (tx `InnerJoin` txOut) -> do
               on (tx ^. TxId ==. txOut ^. TxOutTxId)

--- a/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
@@ -12,8 +12,6 @@ import Cardano.Db
     ( EntityField (..), TxId, unValue3 )
 import Control.Monad.IO.Class
     ( MonadIO )
-import Control.Monad.Trans.Reader
-    ( ReaderT )
 import Data.ByteString.Char8
     ( ByteString )
 import Data.Int
@@ -44,12 +42,11 @@ import Database.Esqueleto
     , (^.)
     )
 import Database.Persist.Sql
-    ( SqlBackend )
+    ( SqlPersistT )
 import Explorer.Web.Api.Legacy.Util
     ( bsBase16Encode
     , collapseTxGroup
     , genesisDistributionTxHash
-    , runQuery
     , textBase16Decode
     , zipTxBrief
     )
@@ -63,8 +60,6 @@ import Explorer.Web.ClientTypes
     )
 import Explorer.Web.Error
     ( ExplorerError (..) )
-import Servant
-    ( Handler )
 
 -- Example queries:
 --
@@ -75,20 +70,21 @@ import Servant
 --  /api/blocks/txs/619457f25781b1c32c935e711a019d8c584574b363b27f3ae1393bddb895017a
 
 blocksTxs
-    :: SqlBackend -> CHash
+    :: MonadIO m
+    => CHash
     -> Maybe Int64
     -> Maybe Int64
-    -> Handler (Either ExplorerError [CTxBrief])
-blocksTxs backend (CHash blkHashTxt) mLimit mOffset =
+    -> SqlPersistT m (Either ExplorerError [CTxBrief])
+blocksTxs (CHash blkHashTxt) mLimit mOffset =
     case textBase16Decode blkHashTxt of
       Left err -> pure $ Left err
-      Right blkHash -> runQuery backend $ queryBlocksTxs blkHash pageSize page
+      Right blkHash -> queryBlocksTxs blkHash pageSize page
   where
     pageSize = fromMaybe 10 mLimit
     page = fromMaybe 0 mOffset
 
 
-queryBlocksTxs :: MonadIO m => ByteString -> Int64 -> Int64 -> ReaderT SqlBackend m (Either ExplorerError [CTxBrief])
+queryBlocksTxs :: MonadIO m => ByteString -> Int64 -> Int64 -> SqlPersistT m (Either ExplorerError [CTxBrief])
 queryBlocksTxs blkHash _limitNum _offsetNum  = do
     res <- select . from $ \  (blk `InnerJoin` tx) -> do
             on (blk ^. BlockId ==. tx ^. TxBlock)
@@ -100,13 +96,13 @@ queryBlocksTxs blkHash _limitNum _offsetNum  = do
       [] -> pure $ Left (Internal "No block found")
       xs -> Right <$> queryCTxBriefs xs
 
-queryCTxBriefs :: MonadIO m => [(TxId, ByteString, UTCTime)] -> ReaderT SqlBackend m [CTxBrief]
+queryCTxBriefs :: MonadIO m => [(TxId, ByteString, UTCTime)] -> SqlPersistT m [CTxBrief]
 queryCTxBriefs [] = pure []
 queryCTxBriefs xs = do
   let txids = map fst3 xs
   zipTxBrief xs <$> queryTxInputs txids <*> queryTxOutputs txids
 
-queryTxInputs :: MonadIO m => [TxId] -> ReaderT SqlBackend m [(TxId, [CTxAddressBrief])]
+queryTxInputs :: MonadIO m => [TxId] -> SqlPersistT m [(TxId, [CTxAddressBrief])]
 queryTxInputs txids = do
     rows <- select . distinct . from $ \(tx `InnerJoin` txIn `InnerJoin` txOut `InnerJoin` txInTx) -> do
               on (txInTx ^. TxId ==. txIn ^. TxInTxOutId)
@@ -137,7 +133,7 @@ queryTxInputs txids = do
               }
       )
 
-queryTxOutputs :: MonadIO m => [TxId] -> ReaderT SqlBackend m [(TxId, [CTxAddressBrief])]
+queryTxOutputs :: MonadIO m => [TxId] -> SqlPersistT m [(TxId, [CTxAddressBrief])]
 queryTxOutputs txids = do
     rows <- select . from $ \ (tx `InnerJoin` txOut) -> do
               on (tx ^. TxId ==. txOut ^. TxOutTxId)

--- a/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 
 module Explorer.Web.Api.Legacy.BlocksTxs
   ( blocksTxs

--- a/explorer-api/src/Explorer/Web/Api/Legacy/EpochPage.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/EpochPage.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Explorer.Web.Api.Legacy.EpochPage
   ( epochPage

--- a/explorer-api/src/Explorer/Web/Api/Legacy/EpochPage.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/EpochPage.hs
@@ -10,8 +10,6 @@ import Cardano.Db
     ( Block (..), EntityField (..) )
 import Control.Monad.IO.Class
     ( MonadIO )
-import Control.Monad.Trans.Reader
-    ( ReaderT )
 import Data.ByteString
     ( ByteString )
 import Data.Fixed
@@ -47,17 +45,15 @@ import Database.Esqueleto
     , (^.)
     )
 import Database.Persist.Sql
-    ( SqlBackend )
+    ( SqlPersistT )
 import Explorer.Web.Api.Legacy.Types
     ( PageNo (..) )
 import Explorer.Web.Api.Legacy.Util
-    ( bsBase16Encode, divRoundUp, runQuery, slotsPerEpoch, textShow )
+    ( bsBase16Encode, divRoundUp, slotsPerEpoch, textShow )
 import Explorer.Web.ClientTypes
     ( CBlockEntry (..), CHash (..), mkCCoin )
 import Explorer.Web.Error
     ( ExplorerError (..) )
-import Servant
-    ( Handler )
 
 import qualified Data.List as List
 
@@ -69,10 +65,10 @@ import qualified Data.List as List
 --  /api/epochs/1?page=2
 
 epochPage
-    :: SqlBackend -> EpochNumber -> Maybe PageNo
-    -> Handler (Either ExplorerError (Int, [CBlockEntry]))
-epochPage backend (EpochNumber epoch) mPageNo = do
-    runQuery backend $ do
+    :: MonadIO m
+    => EpochNumber -> Maybe PageNo
+    -> SqlPersistT m (Either ExplorerError (Int, [CBlockEntry]))
+epochPage (EpochNumber epoch) mPageNo = do
       mEpochBlocks <- queryEpochBlockCount epoch
       case mEpochBlocks of
         Nothing -> pure $ Left (noBlocksFound epoch mPageNo)
@@ -80,7 +76,7 @@ epochPage backend (EpochNumber epoch) mPageNo = do
         Just epochBlocks -> queryEpochBlocks epoch epochBlocks (fromMaybe (PageNo 1) mPageNo)
 
 
-queryEpochBlockCount :: MonadIO m => Word64 -> ReaderT SqlBackend m (Maybe Int)
+queryEpochBlockCount :: MonadIO m => Word64 -> SqlPersistT m (Maybe Int)
 queryEpochBlockCount epoch = do
   res <- select . from $ \ blk -> do
           where_ (blk ^. BlockEpochNo ==. just (val epoch))
@@ -90,7 +86,7 @@ queryEpochBlockCount epoch = do
 queryEpochBlocks
     :: MonadIO m
     => Word64 -> Int -> PageNo
-    -> ReaderT SqlBackend m (Either ExplorerError (Int, [CBlockEntry]))
+    -> SqlPersistT m (Either ExplorerError (Int, [CBlockEntry]))
 queryEpochBlocks epoch epochBlocks (PageNo page) = do
     rows <- select . from $ \ ((sl `InnerJoin` blk) `LeftOuterJoin` tx) -> do
               on (just (blk ^. BlockId) ==. tx ?. TxBlock)
@@ -133,4 +129,3 @@ noBlocksFound epoch mPageNo =
   where
     msg :: Text
     msg = "No blocks found for epoch #" <> textShow epoch
-

--- a/explorer-api/src/Explorer/Web/Api/Legacy/TxLast.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/TxLast.hs
@@ -8,8 +8,6 @@ import Cardano.Db
     ( EntityField (..), Tx, isJust )
 import Control.Monad.IO.Class
     ( MonadIO )
-import Control.Monad.Trans.Reader
-    ( ReaderT )
 import Data.ByteString.Char8
     ( ByteString )
 import Data.Fixed
@@ -37,22 +35,19 @@ import Database.Esqueleto
     , (^.)
     )
 import Database.Persist.Sql
-    ( SqlBackend )
+    ( SqlPersistT )
 import Explorer.Web.Api.Legacy.Util
 import Explorer.Web.ClientTypes
     ( CHash (..), CTxEntry (..), CTxHash (..), mkCCoin )
 import Explorer.Web.Error
     ( ExplorerError (..) )
-import Servant
-    ( Handler )
 
 
-getLastTxs :: SqlBackend -> Handler (Either ExplorerError [CTxEntry])
-getLastTxs backend =
-  runQuery backend $ Right <$> queryCTxEntry
+getLastTxs :: MonadIO m => SqlPersistT m (Either ExplorerError [CTxEntry])
+getLastTxs = Right <$> queryCTxEntry
 
 
-queryCTxEntry :: MonadIO m => ReaderT SqlBackend m [CTxEntry]
+queryCTxEntry :: MonadIO m => SqlPersistT m [CTxEntry]
 queryCTxEntry = do
     txRows <- select . from $ \ (blk `InnerJoin` tx) -> do
                 on (blk ^. BlockId ==. tx ^. TxBlock)

--- a/explorer-api/src/Explorer/Web/Api/Legacy/TxsSummary.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/TxsSummary.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Explorer.Web.Api.Legacy.TxsSummary

--- a/explorer-api/src/Explorer/Web/Api/Legacy/Util.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/Util.hs
@@ -24,8 +24,6 @@ import Cardano.Db
     ( Block (..), TxId )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
-import Control.Monad.Trans.Reader
-    ( ReaderT )
 import Data.Bifunctor
     ( first )
 import Data.ByteString
@@ -43,7 +41,7 @@ import Data.Time.Clock.POSIX
 import Data.Word
     ( Word16, Word64 )
 import Database.Persist.Sql
-    ( IsolationLevel (..), SqlBackend, runSqlConnWithIsolation )
+    ( IsolationLevel (..), SqlBackend, runSqlConnWithIsolation, SqlPersistT)
 import Explorer.Web.Api.Legacy.Types
     ( PageSize (..) )
 import Explorer.Web.ClientTypes
@@ -100,7 +98,7 @@ genesisDistributionTxHash = CTxHash (CHash "Genesis Distribution")
 k :: Word64
 k = 2160
 
-runQuery :: MonadIO m => SqlBackend -> ReaderT SqlBackend IO a -> m a
+runQuery :: MonadIO m => SqlBackend -> SqlPersistT IO a -> m a
 runQuery backend query =
   liftIO $ runSqlConnWithIsolation query backend Serializable
 

--- a/explorer-api/src/Explorer/Web/Query.hs
+++ b/explorer-api/src/Explorer/Web/Query.hs
@@ -22,8 +22,6 @@ import Cardano.Db
     )
 import Control.Monad.IO.Class
     ( MonadIO )
-import Control.Monad.Trans.Reader
-    ( ReaderT )
 import Data.ByteString
     ( ByteString )
 import Data.Maybe
@@ -51,20 +49,20 @@ import Database.Esqueleto
     , (^.)
     )
 import Database.Persist.Sql
-    ( Entity (..), SqlBackend )
+    ( Entity (..), SqlPersistT )
 import Explorer.Web.Api.Legacy.Util
     ( bsBase16Encode )
 import Explorer.Web.ClientTypes
     ( CChainTip (..), CHash (..) )
 
-queryBlockHash :: MonadIO m => BlockId -> ReaderT SqlBackend m (Maybe ByteString)
+queryBlockHash :: MonadIO m => BlockId -> SqlPersistT m (Maybe ByteString)
 queryBlockHash blkid = do
   rows <- select . from $ \blk -> do
     where_ $ blk ^. BlockId ==. val blkid
     pure $ blk ^. BlockHash
   pure (unValue <$> listToMaybe rows)
 
-queryChainTip :: MonadIO m => ReaderT SqlBackend m CChainTip
+queryChainTip :: MonadIO m => SqlPersistT m CChainTip
 queryChainTip = do
     rows <- select . from $ \ blk -> do
               where_ (isJust (blk ^. BlockBlockNo))
@@ -84,18 +82,18 @@ queryChainTip = do
     defTip :: CChainTip
     defTip = CChainTip 0 0 (CHash "unknown")
 
-queryNextBlock :: MonadIO m => BlockId -> ReaderT SqlBackend m (Maybe ByteString)
+queryNextBlock :: MonadIO m => BlockId -> SqlPersistT m (Maybe ByteString)
 queryNextBlock blkid = do
   rows <- select . from $ \blk2 -> do
     where_ $ blk2 ^. BlockPrevious ==. val (Just blkid)
     pure $ blk2 ^. BlockHash
   pure (unValue <$> listToMaybe rows)
 
-queryBlockTxInCount :: MonadIO m => BlockId -> ReaderT SqlBackend m Word
+queryBlockTxInCount :: MonadIO m => BlockId -> SqlPersistT m Word
 queryBlockTxInCount blkid =
   querySelectCount $ \tx -> where_ (tx ^. TxBlock ==. val blkid)
 
-queryBlockByHash :: MonadIO m => ByteString -> ReaderT SqlBackend m (Maybe (BlockId, Block, ByteString))
+queryBlockByHash :: MonadIO m => ByteString -> SqlPersistT m (Maybe (BlockId, Block, ByteString))
 queryBlockByHash blkHash = do
     rows <- select . from $ \ (blk `InnerJoin` sl)-> do
               on (blk ^. BlockSlotLeader ==. sl ^. SlotLeaderId)
@@ -106,7 +104,9 @@ queryBlockByHash blkHash = do
     convert :: (Entity Block, Value ByteString) -> (BlockId, Block, ByteString)
     convert (eb, vsh) = (entityKey eb, entityVal eb, unValue vsh)
 
-queryBlockSummary :: MonadIO m => ByteString -> ReaderT SqlBackend m (Maybe (Block, ByteString, Maybe ByteString, Word, Ada, Ada, ByteString, Maybe POSIXTime))
+queryBlockSummary ::
+  MonadIO m
+  => ByteString -> SqlPersistT m (Maybe (Block, ByteString, Maybe ByteString, Word, Ada, Ada, ByteString, Maybe POSIXTime))
 queryBlockSummary blkHash = do
   maybeBlock <- queryBlockByHash blkHash
   case maybeBlock of
@@ -125,18 +125,18 @@ queryBlockSummary blkHash = do
         Nothing -> pure Nothing
     Nothing -> pure Nothing
 
-querySlotTimeSeconds :: MonadIO m => Word64 -> ReaderT SqlBackend m (Maybe POSIXTime)
+querySlotTimeSeconds :: MonadIO m => Word64 -> SqlPersistT m (Maybe POSIXTime)
 querySlotTimeSeconds slotNo =
   either (const Nothing) Just <$> querySlotPosixTime slotNo
 
-queryTotalFeeInBlock :: MonadIO m => BlockId -> ReaderT SqlBackend m Ada
+queryTotalFeeInBlock :: MonadIO m => BlockId -> SqlPersistT m Ada
 queryTotalFeeInBlock blockid = do
   res <- select . from $ \ tx -> do
           where_ (tx ^. TxBlock ==. val blockid)
           pure $ sum_ (tx ^. TxFee)
   pure $ unValueSumAda $ listToMaybe res
 
-queryTotalOutputCoinInBlock :: MonadIO m => BlockId -> ReaderT SqlBackend m Ada
+queryTotalOutputCoinInBlock :: MonadIO m => BlockId -> SqlPersistT m Ada
 queryTotalOutputCoinInBlock blockid = do
     res <- select . from $ \ txOut -> do
             where_ $ txOut ^. TxOutTxId `in_` subQuery


### PR DESCRIPTION
N/A


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

Refactoring our use of SqlBackend.

There are lots of places in this code where we run in a `ReaderT 
SqlBackend` monad *and* pass a `SqlBackend` around manually.

I've neatened this up as much as I can by removing the manual
backend-passing, and hoisting the `runQuery backend` call into Servant's
hoistServer mechanism.

The end result is, IMHO, much cleaner.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->