### PR TITLE
Bugfix for the release.nix build of cardano-rest-macos64.

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -129,6 +129,7 @@ let
     in pkgs.runCommand "${name}-macos64" {
       buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils nix ];
     } ''
+      mkdir -p ${name}/bin
       cp -R ${jobs.native.cardano-explorer-api.x86_64-darwin}/bin ${name}
       cp -R ${jobs.native.cardano-submit-api.x86_64-darwin}/bin ${name}
       chmod -R 755 ${name}


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [X] The nix build of `cardano-rest-macos64` was failing because a needed directory didn't exist.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->