### PR TITLE
Change to nix-shell.project such that 'cabal repl' will start.

### DIFF
--- a/nix-shell.project
+++ b/nix-shell.project
@@ -7,15 +7,15 @@ packages:
 
 package cardano-rest-common
   tests: True
-  ghc-options: -Wall -Werror -fwarn-redundant-constraints
+  ghc-options: -Wall -Werror -fwarn-redundant-constraints -Wno-error=missing-local-signatures
 
 package cardano-explorer-api
   tests: True
-  ghc-options: -Wall -Werror -fwarn-redundant-constraints
+  ghc-options: -Wall -Werror -fwarn-redundant-constraints -Wno-error=missing-local-signatures
 
 package cardano-submit-api
   tests: True
-  ghc-options: -Wall -Werror -fwarn-redundant-constraints
+  ghc-options: -Wall -Werror -fwarn-redundant-constraints -Wno-error=missing-local-signatures
 
 package cardano-db-sync
   tests: False


### PR DESCRIPTION
# Issue Number

N/A.


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [X] `cabal new-repl` was failing for anyone using the nix-shell setup. This fixes it.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->