### PR TITLE
Refactoring the validator and fixing some small bugs.

### DIFF
--- a/explorer-api/app/Explorer/Web/Validate/Random.hs
+++ b/explorer-api/app/Explorer/Web/Validate/Random.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Explorer.Web.Validate.Random
   ( queryRandomAddress
@@ -8,16 +10,9 @@ module Explorer.Web.Validate.Random
   ) where
 
 import Cardano.Db
-    ( BlockId
-    , EntityField (..)
-    , Key (..)
-    , LookupFail (..)
-    , TxOut (..)
-    , TxOutId
-    , maybeToEither
-    )
+    ( BlockId, EntityField (..), Key (..), LookupFail (..), maybeToEither )
 import Control.Monad.IO.Class
-    ( MonadIO, liftIO )
+    ( MonadIO )
 import Control.Monad.Trans.Reader
     ( ReaderT )
 import Data.ByteString.Char8
@@ -27,15 +22,14 @@ import Data.Maybe
 import Data.Text
     ( Text )
 import Database.Esqueleto
-    ( Entity (..)
-    , InnerJoin (..)
+    ( InnerJoin (..)
+    , SqlBackend
     , SqlExpr
+    , SqlQuery
     , Value (..)
     , asc
-    , countRows
     , from
     , limit
-    , offset
     , on
     , orderBy
     , select
@@ -45,70 +39,54 @@ import Database.Esqueleto
     , (>.)
     , (^.)
     )
-import Database.Persist.Sql
-    ( SqlBackend )
-import System.Random
-    ( randomRIO )
-
+import Database.Esqueleto.PostgreSQL
+    ( random_ )
 
 -- | Get a random address.
 queryRandomAddress :: MonadIO m => ReaderT SqlBackend m (Either LookupFail Text)
 queryRandomAddress = do
-    res <- select . from $ \ (_ :: SqlExpr (Entity TxOut)) ->
-              pure countRows
-    case listToMaybe res of
-      Nothing -> pure $ Left (DbLookupMessage "queryRandomAddress: Empty TxOut table")
-      Just (Value txoCount) -> do
-        txoid <- liftIO $ randomRIO (1, txoCount - 1)
-        res1 <- select . from $ \ txOut -> do
-                  where_ (txOut ^. TxOutId ==. val (mkTxOutId txoid))
-                  pure (txOut ^. TxOutAddress)
-        pure $ maybeToEither errMsg unValue (listToMaybe res1)
+    res <- select . from $ \ txOut -> do
+             firstRandomRow
+             pure (txOut ^. TxOutAddress)
+    pure $ maybeToEither errMsg unValue (listToMaybe res)
   where
     errMsg :: LookupFail
-    errMsg = DbLookupMessage "queryRandomAddress: Lookup address by index failed"
+    errMsg = DbLookupMessage "queryRandomAddress: Lookup random address failed"
 
 queryRandomBlockHash :: MonadIO m => ReaderT SqlBackend m (Either LookupFail ByteString)
 queryRandomBlockHash = do
     res <- select . from $ \ blk -> do
-              where_ (blk ^. BlockTxCount >. val 0)
-              pure countRows
-    case listToMaybe res of
-      Nothing -> pure $ Left (DbLookupMessage "queryRandomBlockHash: Empty Block table")
-      Just (Value blkCount) -> do
-        blkid <- liftIO $ randomRIO (1, blkCount - 1)
-        res1 <- select . from $ \ blk -> do
-                  where_ (blk ^. BlockTxCount >. val 0)
-                  orderBy [asc (blk ^. BlockId)]
-                  offset blkid
-                  limit 1
-                  pure (blk ^. BlockHash)
-        pure $ maybeToEither errMsg unValue (listToMaybe res1)
+             where_ (blk ^. BlockTxCount >. val 0)
+             firstRandomRow
+             limit 1
+             pure (blk ^. BlockHash)
+    pure $ maybeToEither errMsg unValue (listToMaybe res)
   where
     errMsg :: LookupFail
-    errMsg = DbLookupMessage "queryRandomBlockHash: Lookup block by index failed"
+    errMsg = DbLookupMessage "queryRandomBlockHash: Lookup random block failed"
 
 queryRandomRedeemAddress :: MonadIO m => ReaderT SqlBackend m (Either LookupFail Text)
 queryRandomRedeemAddress = do
     res <- select . from $ \ (tx `InnerJoin` txOut) -> do
-              on (tx ^. TxId ==. txOut ^. TxOutTxId)
-              -- Block 1 contains all the TxOuts from the Genesis Distribution.
-              where_ (tx ^. TxBlock ==. val (mkBlockId 1))
-              pure countRows
-    case listToMaybe res of
-      Nothing -> pure $ Left (DbLookupMessage "queryRandomAddress: Empty TxOut table")
-      Just (Value txoCount) -> do
-        txoid <- liftIO $ randomRIO (1, txoCount - 1)
-        res1 <- select . from $ \ txOut -> do
-                  where_ (txOut ^. TxOutId ==. val (mkTxOutId txoid))
-                  pure (txOut ^. TxOutAddress)
-        pure $ maybeToEither errMsg unValue (listToMaybe res1)
+             -- Block 1 contains all the TxOuts from the Genesis Distribution.
+             where_ (tx ^. TxBlock ==. val (mkBlockId 1))
+             on (tx ^. TxId ==. txOut ^. TxOutTxId)
+             firstRandomRow
+             pure (txOut ^. TxOutAddress)
+    pure $ maybeToEither errMsg unValue (listToMaybe res)
   where
-    errMsg :: LookupFail
-    errMsg = DbLookupMessage "queryRandomRedeemAddress: Lookup address by index failed"
-
-mkTxOutId :: Word -> TxOutId
-mkTxOutId = TxOutKey . fromIntegral
+    errMsg ::  LookupFail
+    errMsg = DbLookupMessage "queryRandomRedeemAddress: Lookup random address failed"
 
 mkBlockId :: Word -> BlockId
 mkBlockId = BlockKey . fromIntegral
+
+-- | Filter a table to pick a row at random row from the database.
+--
+-- Note: This will be fine for ad-hoc queries, but if you use it for
+-- anything high-performance, you should test it thoroughly first and
+-- consider alternative approaches.
+firstRandomRow :: SqlQuery ()
+firstRandomRow = do
+  orderBy [asc (random_ :: SqlExpr (Value Int))]
+  limit 1

--- a/explorer-api/app/cardano-explorer-api-validate.hs
+++ b/explorer-api/app/cardano-explorer-api-validate.hs
@@ -53,7 +53,9 @@ pCommand =
 
     pCount :: Parser Word
     pCount =
-      read <$> Opt.strOption
+      Opt.option Opt.auto
         (  Opt.long "count"
-        <> Opt.help "The number of validations to run (default is 10)."
+        <> Opt.help "The number of validations to run."
+        <> Opt.value 10
+        <> Opt.showDefault
         )

--- a/explorer-api/src/Explorer/Web/Api/Legacy/AddressSummary.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/AddressSummary.hs
@@ -177,7 +177,7 @@ queryTxInputs txids = do
             CTxAddressBrief
               { ctaAddress = CAddress addr
               , ctaAmount = mkCCoin $ fromIntegral coin
-              , ctaTxHash = if True then genesisDistributionTxHash else CTxHash (CHash "queryTxInputs Genesis")
+              , ctaTxHash = genesisDistributionTxHash
               , ctaTxIndex = 0
               }
           else

--- a/explorer-api/src/Explorer/Web/Api/Legacy/AddressSummary.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/AddressSummary.hs
@@ -57,13 +57,10 @@ import Explorer.Web.ClientTypes
     , CAddressSummary (..)
     , CAddressType (..)
     , CChainTip (..)
-    , CCoin (..)
     , CHash (..)
     , CTxAddressBrief (..)
     , CTxBrief (..)
     , CTxHash (..)
-    , mkCCoin
-    , sumCCoin
     )
 import Explorer.Web.Error
     ( ExplorerError (..) )
@@ -130,17 +127,17 @@ queryNonRedeemSummary chainTip addr = do
   where
     cAddressSummary :: [CTxBrief] -> [CTxBrief] -> CAddressSummary
     cAddressSummary itxs otxs =
-      let insum = sumCCoin . map ctaAmount $ filter isTargetAddress (concatMap ctbOutputs itxs)
-          outsum = sumCCoin . map ctaAmount $ filter isTargetAddress (concatMap ctbInputs otxs)
+      let insum = sum . map ctaAmount $ filter isTargetAddress (concatMap ctbOutputs itxs)
+          outsum = sum . map ctaAmount $ filter isTargetAddress (concatMap ctbInputs otxs)
           txs = List.sortOn ctbTimeIssued (itxs ++ otxs)
-          fees = sumCCoin $ map ctbFees txs
+          fees = sum $ map ctbFees txs
       in
       CAddressSummary
         { caAddress = CAddress addr
         , caType = CPubKeyAddress
         , caChainTip = chainTip
         , caTxNum = fromIntegral $ length txs
-        , caBalance = mkCCoin $ unCCoin insum - unCCoin outsum
+        , caBalance = insum - outsum
         , caTotalInput = insum
         , caTotalOutput = outsum
         , caTotalFee = fees
@@ -176,14 +173,14 @@ queryTxInputs txids = do
           then
             CTxAddressBrief
               { ctaAddress = CAddress addr
-              , ctaAmount = mkCCoin $ fromIntegral coin
+              , ctaAmount = fromIntegral coin
               , ctaTxHash = genesisDistributionTxHash
               , ctaTxIndex = 0
               }
           else
             CTxAddressBrief
               { ctaAddress = CAddress addr
-              , ctaAmount = mkCCoin $ fromIntegral coin
+              , ctaAmount = fromIntegral coin
               , ctaTxHash = CTxHash $ CHash (bsBase16Encode txh)
               , ctaTxIndex = fromIntegral index
               }
@@ -202,7 +199,7 @@ queryTxOutputs txids = do
       ( txid
       , CTxAddressBrief
           { ctaAddress = CAddress addr
-          , ctaAmount = mkCCoin $ fromIntegral coin
+          , ctaAmount = fromIntegral coin
           , ctaTxHash = CTxHash . CHash $ bsBase16Encode txhash
           , ctaTxIndex = fromIntegral index
           }

--- a/explorer-api/src/Explorer/Web/Api/Legacy/BlocksPages.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/BlocksPages.hs
@@ -42,7 +42,7 @@ import Explorer.Web.Api.Legacy.Types
 import Explorer.Web.Api.Legacy.Util
     ( bsBase16Encode, slotsPerEpoch )
 import Explorer.Web.ClientTypes
-    ( CBlockEntry (..), CHash (..), mkCCoin )
+    ( CBlockEntry (..), CHash (..) )
 import Explorer.Web.Error
     ( ExplorerError (..) )
 import qualified Data.List as List
@@ -135,8 +135,8 @@ queryCBlockEntry (Entity blkId block, Value slHash) = do
         , cbeBlkHash = CHash $ bsBase16Encode (blockHash block)
         , cbeTimeIssued = Just $ utcTimeToPOSIXSeconds (blockTime block)
         , cbeTxNum = fromIntegral $ length xs
-        , cbeTotalSent = mkCCoin $ fromIntegral (sum $ map fst xs)
+        , cbeTotalSent = fromIntegral (sum $ map fst xs)
         , cbeSize = blockSize block
         , cbeBlockLead = Just $ bsBase16Encode slHash
-        , cbeFees = mkCCoin $ fromIntegral (sum $ map snd xs)
+        , cbeFees = fromIntegral (sum $ map snd xs)
         }

--- a/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
@@ -55,7 +55,6 @@ import Explorer.Web.ClientTypes
     , CTxAddressBrief (..)
     , CTxBrief (..)
     , CTxHash (..)
-    , mkCCoin
     )
 import Explorer.Web.Error
     ( ExplorerError (..) )
@@ -119,14 +118,14 @@ queryTxInputs txids = do
           then
             CTxAddressBrief
               { ctaAddress = CAddress addr
-              , ctaAmount = mkCCoin $ fromIntegral coin
+              , ctaAmount = fromIntegral coin
               , ctaTxHash = genesisDistributionTxHash
               , ctaTxIndex = 0
               }
           else
             CTxAddressBrief
               { ctaAddress = CAddress addr
-              , ctaAmount = mkCCoin $ fromIntegral coin
+              , ctaAmount = fromIntegral coin
               , ctaTxHash = CTxHash $ CHash (bsBase16Encode txh)
               , ctaTxIndex = fromIntegral index
               }
@@ -145,7 +144,7 @@ queryTxOutputs txids = do
       ( txid
       , CTxAddressBrief
           { ctaAddress = CAddress addr
-          , ctaAmount = mkCCoin $ fromIntegral coin
+          , ctaAmount = fromIntegral coin
           , ctaTxHash = CTxHash . CHash $ bsBase16Encode txhash
           , ctaTxIndex = fromIntegral index
           }

--- a/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
@@ -120,7 +120,7 @@ queryTxInputs txids = do
             CTxAddressBrief
               { ctaAddress = CAddress addr
               , ctaAmount = mkCCoin $ fromIntegral coin
-              , ctaTxHash = if True then genesisDistributionTxHash else CTxHash (CHash "queryTxInputs Genesis")
+              , ctaTxHash = genesisDistributionTxHash
               , ctaTxIndex = 0
               }
           else

--- a/explorer-api/src/Explorer/Web/Api/Legacy/EpochPage.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/EpochPage.hs
@@ -50,7 +50,7 @@ import Explorer.Web.Api.Legacy.Types
 import Explorer.Web.Api.Legacy.Util
     ( bsBase16Encode, divRoundUp, slotsPerEpoch, textShow )
 import Explorer.Web.ClientTypes
-    ( CBlockEntry (..), CHash (..), mkCCoin )
+    ( CBlockEntry (..), CHash (..) )
 import Explorer.Web.Error
     ( ExplorerError (..) )
 
@@ -110,14 +110,15 @@ queryEpochBlocks epoch epochBlocks (PageNo page) = do
         , cbeBlkHash = CHash $ bsBase16Encode (blockHash blk)
         , cbeTimeIssued = Just $ utcTimeToPOSIXSeconds (blockTime blk)
         , cbeTxNum = fromIntegral (blockTxCount blk)
-        , cbeTotalSent = mkCCoin $ unTotal vmOutSum
+        , cbeTotalSent = unTotal vmOutSum
         , cbeSize = blockSize blk
         , cbeBlockLead = Just $ bsBase16Encode slh
-        , cbeFees = mkCCoin $ unTotal vmFee
+        , cbeFees = unTotal vmFee
         }
 
-unTotal :: Value (Maybe Uni) -> Integer
+unTotal :: Num a => Value (Maybe Uni) -> a
 unTotal mvi =
+  fromIntegral $
   case unValue mvi of
     Just (MkFixed x) -> x
     _ -> 0

--- a/explorer-api/src/Explorer/Web/Api/Legacy/EpochSlot.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/EpochSlot.hs
@@ -37,7 +37,7 @@ import Database.Persist.Sql
     ( SqlPersistT )
 import Explorer.Web.Api.Legacy.Util
 import Explorer.Web.ClientTypes
-    ( CBlockEntry (..), CHash (..), mkCCoin )
+    ( CBlockEntry (..), CHash (..) )
 import Explorer.Web.Error
     ( ExplorerError (..) )
 
@@ -81,10 +81,10 @@ queryBlockBySlotNo flatSlotNo = do
                 , cbeBlkHash = CHash $ bsBase16Encode (blockHash block)
                 , cbeTimeIssued = Just $ blockPosixTime block
                 , cbeTxNum = 0
-                , cbeTotalSent = mkCCoin 0
+                , cbeTotalSent = 0
                 , cbeSize = blockSize block
                 , cbeBlockLead = Just $ bsBase16Encode sl
-                , cbeFees = mkCCoin 0
+                , cbeFees = 0
                 })
 
 queryBlockTx :: MonadIO m => (BlockId, CBlockEntry) -> SqlPersistT m CBlockEntry
@@ -108,12 +108,13 @@ queryBlockTx (blkId, entry) = do
     convert txCount fee mValue =
       entry
         { cbeTxNum = txCount
-        , cbeTotalSent = mkCCoin $ unSumValue mValue
-        , cbeFees = mkCCoin fee
+        , cbeTotalSent = unSumValue mValue
+        , cbeFees = fromIntegral fee
         }
 
-unSumValue :: Value (Maybe Uni) -> Integer
+unSumValue :: Num a => Value (Maybe Uni) -> a
 unSumValue mvi =
+  fromIntegral $
   case unValue mvi of
     Just (MkFixed x) -> x
     _ -> 0

--- a/explorer-api/src/Explorer/Web/Api/Legacy/GenesisAddress.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/GenesisAddress.hs
@@ -40,7 +40,7 @@ import Explorer.Web.Api.Legacy.Types
 import Explorer.Web.Api.Legacy.Util
     ( toPageSize )
 import Explorer.Web.ClientTypes
-    ( CAddress (..), CAddressesFilter (..), CGenesisAddressInfo (..), mkCCoin )
+    ( CAddress (..), CAddressesFilter (..), CGenesisAddressInfo (..) )
 import Explorer.Web.Error
     ( ExplorerError (..) )
 
@@ -127,6 +127,6 @@ mkCGenesisAddressInfo :: (Value Text, Value Word64, Value Bool) -> CGenesisAddre
 mkCGenesisAddressInfo (vaddr, vvalue, vRedeemed) =
   CGenesisAddressInfo
     { cgaiCardanoAddress = CAddress (unValue vaddr)
-    , cgaiGenesisAmount = mkCCoin (fromIntegral $ unValue vvalue)
+    , cgaiGenesisAmount = fromIntegral $ unValue vvalue
     , cgaiIsRedeemed = unValue vRedeemed
     }

--- a/explorer-api/src/Explorer/Web/Api/Legacy/GenesisSummary.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/GenesisSummary.hs
@@ -30,7 +30,7 @@ import Database.Esqueleto
 import Database.Persist.Sql
     ( SqlPersistT )
 import Explorer.Web.ClientTypes
-    ( CGenesisSummary (..), mkCCoin )
+    ( CGenesisSummary (..) )
 import Explorer.Web.Error
     ( ExplorerError (..) )
 
@@ -42,8 +42,8 @@ genesisSummary = Right <$> do
             { cgsNumTotal = numTotal
             , cgsNumRedeemed = redTotal
             , cgsNumNotRedeemed = numTotal - redTotal
-            , cgsRedeemedAmountTotal = mkCCoin valRedeemed
-            , cgsNonRedeemedAmountTotal = mkCCoin $ valTotal - valRedeemed
+            , cgsRedeemedAmountTotal = fromIntegral valRedeemed
+            , cgsNonRedeemedAmountTotal = fromIntegral $ valTotal - valRedeemed
             }
 
 queryInitialGenesis :: MonadIO m => SqlPersistT m (Word, Integer)

--- a/explorer-api/src/Explorer/Web/Api/Legacy/RedeemSummary.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/RedeemSummary.hs
@@ -47,7 +47,6 @@ import Explorer.Web.ClientTypes
     , CTxAddressBrief (..)
     , CTxBrief (..)
     , CTxHash (..)
-    , mkCCoin
     )
 import Explorer.Web.Error
     ( ExplorerError (..) )
@@ -68,7 +67,7 @@ queryRedeemSummary chainTip addrTxt = do
               pure (txOut ^. TxOutValue)
     case rows of
       [] -> pure $ Left (Internal "queryRedeemSummary: Address not found")
-      [value] -> Right <$> queryRedeemed (mkCCoin . fromIntegral $ unValue value)
+      [value] -> Right <$> queryRedeemed (fromIntegral $ unValue value)
       _ -> pure $ Left (Internal "queryRedeemSummary: More than one entry")
   where
     queryRedeemed :: MonadIO m => CCoin -> ReaderT SqlBackend m CAddressSummary
@@ -93,9 +92,9 @@ queryRedeemSummary chainTip addrTxt = do
         , caChainTip = chainTip
         , caTxNum = 0
         , caBalance = balance
-        , caTotalInput = mkCCoin 0
-        , caTotalOutput = mkCCoin 0
-        , caTotalFee = mkCCoin 0
+        , caTotalInput = 0
+        , caTotalOutput = 0
+        , caTotalFee = 0
         , caTxList = []
         }
 
@@ -106,10 +105,10 @@ queryRedeemSummary chainTip addrTxt = do
         , caType = CRedeemAddress
         , caChainTip = chainTip
         , caTxNum = 1
-        , caBalance = mkCCoin 0
+        , caBalance = 0
         , caTotalInput = outval
         , caTotalOutput = outval
-        , caTotalFee = mkCCoin 0
+        , caTotalFee = 0
         , caTxList =
             [ CTxBrief
                 { ctbId = CTxHash . CHash $ bsBase16Encode txhash
@@ -132,7 +131,7 @@ queryRedeemSummary chainTip addrTxt = do
                     ]
                 , ctbInputSum = outval
                 , ctbOutputSum = outval
-                , ctbFees = mkCCoin 0
+                , ctbFees = 0
                 }
             ]
         }

--- a/explorer-api/src/Explorer/Web/Api/Legacy/TxLast.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/TxLast.hs
@@ -38,7 +38,7 @@ import Database.Persist.Sql
     ( SqlPersistT )
 import Explorer.Web.Api.Legacy.Util
 import Explorer.Web.ClientTypes
-    ( CHash (..), CTxEntry (..), CTxHash (..), mkCCoin )
+    ( CHash (..), CTxEntry (..), CTxHash (..) )
 import Explorer.Web.Error
     ( ExplorerError (..) )
 
@@ -62,7 +62,7 @@ queryCTxEntry = do
       CTxEntry
         { cteId = CTxHash . CHash $ bsBase16Encode (unValue vhash)
         , cteTimeIssued = Just $ utcTimeToPOSIXSeconds (unValue vtime)
-        , cteAmount = mkCCoin (unTotal vtotal)
+        , cteAmount = unTotal vtotal
         }
 
 txOutValue :: SqlExpr (Entity Tx) -> SqlExpr (Value (Maybe Uni))
@@ -72,8 +72,9 @@ txOutValue tx =
     where_ (txOut ^. TxOutTxId ==. tx ^. TxId)
     pure $ sum_ (txOut ^. TxOutValue)
 
-unTotal :: Value (Maybe Uni) -> Integer
+unTotal :: Num a => Value (Maybe Uni) -> a
 unTotal mvi =
+  fromIntegral $
   case unValue mvi of
     Just (MkFixed x) -> x
     _ -> 0

--- a/explorer-api/src/Explorer/Web/Api/Legacy/TxsSummary.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/TxsSummary.hs
@@ -48,12 +48,10 @@ import Database.Persist.Sql
 import Explorer.Web.Api.Legacy.Util
 import Explorer.Web.ClientTypes
     ( CAddress (..)
-    , CCoin (..)
     , CHash (..)
     , CTxAddressBrief (..)
     , CTxHash (..)
     , CTxSummary (..)
-    , mkCCoin
     )
 import Explorer.Web.Error
     ( ExplorerError (..) )
@@ -89,9 +87,9 @@ txsSummary (CTxHash (CHash hashTxt)) =
               , ctsBlockSlot       = Just $ fromIntegral slot
               , ctsBlockHash       = Just . CHash $ bsBase16Encode (blockHash blk)
               , ctsRelayedBy       = Nothing
-              , ctsTotalInput      = mkCCoin . sum $ map (unCCoin . ctaAmount) inputs
-              , ctsTotalOutput     = mkCCoin . sum $ map (unCCoin . ctaAmount) outputs
-              , ctsFees            = mkCCoin $ fromIntegral (txFee tx)
+              , ctsTotalInput      = sum $ map ctaAmount inputs
+              , ctsTotalOutput     = sum $ map ctaAmount outputs
+              , ctsFees            = fromIntegral $ txFee tx
               , ctsInputs          = inputs
               , ctsOutputs         = outputs
               }
@@ -131,7 +129,7 @@ queryTxOutputs txid = do
     convert (Value addr, Value amount, Value txhash, Value index) =
       CTxAddressBrief
         { ctaAddress = CAddress addr
-        , ctaAmount = mkCCoin $ fromIntegral amount
+        , ctaAmount = fromIntegral amount
         , ctaTxHash = CTxHash $ CHash (bsBase16Encode txhash)
         , ctaTxIndex = fromIntegral index
         }
@@ -156,7 +154,7 @@ queryTxInputs txid = do
     convert (Value addr, Value amount, Value txhash, Value index) =
       CTxAddressBrief
         { ctaAddress = CAddress addr
-        , ctaAmount = mkCCoin $ fromIntegral amount
+        , ctaAmount = fromIntegral amount
         , ctaTxHash = CTxHash $ CHash (bsBase16Encode txhash)
         , ctaTxIndex = fromIntegral index
         }

--- a/explorer-api/src/Explorer/Web/Api/Legacy/Util.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/Util.hs
@@ -45,12 +45,10 @@ import Database.Persist.Sql
 import Explorer.Web.Api.Legacy.Types
     ( PageSize (..) )
 import Explorer.Web.ClientTypes
-    ( CCoin (..)
-    , CHash (..)
+    ( CHash (..)
     , CTxAddressBrief (..)
     , CTxBrief (..)
     , CTxHash (..)
-    , mkCCoin
     )
 import Explorer.Web.Error
     ( ExplorerError (..) )
@@ -122,7 +120,7 @@ unflattenSlotNo w = fromIntegral (w `mod` slotsPerEpoch)
 
 zipTxBrief :: [(TxId, ByteString, UTCTime)] -> [(TxId, [CTxAddressBrief])] -> [(TxId, [CTxAddressBrief])] -> [CTxBrief]
 zipTxBrief xs ins outs =
-    mapMaybe build $ map fst3 xs
+    mapMaybe (build . fst3) xs
   where
     idMap :: Map TxId (ByteString, UTCTime)
     idMap = Map.fromList $ map (\(a, b, c) -> (a, (b, c))) xs
@@ -138,14 +136,14 @@ zipTxBrief xs ins outs =
       (hash, time) <- Map.lookup txid idMap
       inputs <- Map.lookup txid inMap
       outputs <- Map.lookup txid outMap
-      inSum <- Just $ sum (map (unCCoin . ctaAmount) inputs)
-      outSum <- Just $ sum (map (unCCoin . ctaAmount) outputs)
+      inSum <- Just $ sum (map ctaAmount inputs)
+      outSum <- Just $ sum (map ctaAmount outputs)
       pure $ CTxBrief
               { ctbId = CTxHash . CHash $ bsBase16Encode hash
               , ctbTimeIssued = Just $ utcTimeToPOSIXSeconds time
               , ctbInputs = inputs
               , ctbOutputs = outputs
-              , ctbInputSum = mkCCoin inSum
-              , ctbOutputSum = mkCCoin outSum
-              , ctbFees = mkCCoin (inSum - outSum)
+              , ctbInputSum = inSum
+              , ctbOutputSum = outSum
+              , ctbFees = inSum - outSum
               }

--- a/explorer-api/src/Explorer/Web/ClientTypes.hs
+++ b/explorer-api/src/Explorer/Web/ClientTypes.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -36,10 +37,8 @@ module Explorer.Web.ClientTypes
        , CCoin(..)
        , CByteString (..)
        , toCHash
-       , mkCCoin
        , adaToCCoin
        , cCoinToAda
-       , sumCCoin
        ) where
 
 import Cardano.Crypto.Hash.Class
@@ -128,22 +127,16 @@ newtype CNetwork = CNetwork Text
 newtype CCoin = CCoin
     { unCCoin :: Integer
     } deriving (Show, Generic, Eq)
+      deriving newtype (Num, Ord)
 
 instance ToJSON CCoin where
   toJSON (CCoin coin) = Aeson.object [ ("getCoin", Aeson.String (T.pack $ show coin)) ]
-
-mkCCoin :: Integer -> CCoin
-mkCCoin = CCoin
 
 adaToCCoin :: Ada -> CCoin
 adaToCCoin (Ada (MkFixed ll)) = CCoin ll
 
 cCoinToAda :: CCoin -> Ada
 cCoinToAda (CCoin ll) = Ada (MkFixed ll)
-
-
-sumCCoin :: [CCoin] -> CCoin
-sumCCoin = mkCCoin . sum . map unCCoin
 
 -- | List of block entries is returned from "get latest N blocks" endpoint
 data CBlockEntry = CBlockEntry


### PR DESCRIPTION
# Issue Number

Fixes #51.


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- Refactoring CCoin to simplify some calculation code.
- Refactoring. `if True then x ...` is _always_ `x`.
- Bugfix for the release.nix build of cardano-rest-macos64.
- Bugfix: cardano-explorer-api-validate wrongly claims to have a default count of 10.
- Bugfix: cardano-explorer-api-validate is intermittently failing to find a random row.



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->