### PR TITLE
Remove unused cardano-submit-api configuration fields

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,17 +1,4 @@
 {
-    "cardano-node": {
-        "branch": "master",
-        "description": null,
-        "homepage": null,
-        "owner": "input-output-hk",
-        "repo": "cardano-node",
-        "rev": "a01b3594b6d7b478b235ca9d305a516c7cb28972",
-        "sha256": "0wxzflz0fz6gzj5y1571r4x7ks2z59mpf53k1wr56fv48qbfrkhw",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/a01b3594b6d7b478b235ca9d305a516c7cb28972.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "version": "1.6.0"
-    },
     "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
@@ -30,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "00788ac974a517846dba09bd5e095757011cb083",
-        "sha256": "0lxffzd31a359d7j9q0vwaj6d5lq0ka5df6g0g30rm91sw7jkpnj",
+        "rev": "9c6c9d57671310ae399f3babb3a2b419123d5a49",
+        "sha256": "17scxhb2jb11gcxjg7d6czqz8jh8ncrwqxv5bpk4k5ziwkyyva50",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/00788ac974a517846dba09bd5e095757011cb083.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/9c6c9d57671310ae399f3babb3a2b419123d5a49.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/submit-api/config/tx-submit-mainnet-config.yaml
+++ b/submit-api/config/tx-submit-mainnet-config.yaml
@@ -1,7 +1,5 @@
-# Explorer DB Node configuration
+# Tx Submission Server Configuration
 
-RequiresNetworkMagic: RequiresNoMagic
-GenesisHash: 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb
 EnableLogMetrics: False
 EnableLogging: True
 
@@ -100,4 +98,3 @@ options:
       - AggregationBK
     '#aggregation.cardano.epoch-validation.benchmark':
       - EKGViewBK
-

--- a/submit-api/src/Cardano/TxSubmit/Config.hs
+++ b/submit-api/src/Cardano/TxSubmit/Config.hs
@@ -5,7 +5,6 @@
 
 module Cardano.TxSubmit.Config
   ( TxSubmitNodeConfig
-  , GenesisHash (..)
   , GenTxSubmitNodeConfig (..)
   , readTxSubmitNodeConfig
   ) where
@@ -13,8 +12,6 @@ module Cardano.TxSubmit.Config
 import qualified Cardano.BM.Configuration as Logging
 import qualified Cardano.BM.Configuration.Model as Logging
 import qualified Cardano.BM.Data.Configuration as Logging
-
-import           Cardano.Crypto (RequiresNetworkMagic (..))
 
 import           Cardano.Prelude
 
@@ -24,7 +21,6 @@ import           Data.Aeson (FromJSON (..), Object, Value (..), (.:))
 import           Data.Aeson.Types (Parser)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as BS
-import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Yaml as Yaml
 
@@ -32,16 +28,9 @@ type TxSubmitNodeConfig = GenTxSubmitNodeConfig Logging.Configuration
 
 data GenTxSubmitNodeConfig a = GenTxSubmitNodeConfig
   { tscLoggingConfig :: !a
-  , tscGenesisHash :: !GenesisHash
   , tscEnableLogging :: !Bool
   , tscEnableMetrics :: !Bool
-  , tscRequiresNetworkMagic :: !RequiresNetworkMagic
   }
-
-newtype GenesisHash = GenesisHash
-  { unGenesisHash :: Text
-  }
-
 
 readTxSubmitNodeConfig :: FilePath -> IO TxSubmitNodeConfig
 readTxSubmitNodeConfig fp = do
@@ -70,7 +59,5 @@ parseGenTxSubmitNodeConfig :: Object -> Parser (GenTxSubmitNodeConfig Logging.Re
 parseGenTxSubmitNodeConfig o =
   GenTxSubmitNodeConfig
     <$> parseJSON (Object o)
-    <*> fmap GenesisHash (o .: "GenesisHash")
     <*> o .: "EnableLogging"
     <*> o .: "EnableLogMetrics"
-    <*> o .: "RequiresNetworkMagic"


### PR DESCRIPTION
Previously, I forgot to remove unused fields such as `GenesisHash` and `RequiresNetworkMagic` from the `TxSubmitNodeConfig` data type.