### PR TITLE
docker image: remove hack

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -137,10 +137,7 @@ let
   submitApiDockerImage = let
     clusterStatements = lib.concatStringsSep "\n" (lib.mapAttrsToList (_: value: value) (commonLib.forEnvironments (env: ''
       elif [[ "$NETWORK" == "${env.name}" ]]; then
-        ${if (env ? submitApiConfig) then "exec ${scripts.${env.name}.submit-api}"
-        else ''
-          tx submission not supported on ${env.name}
-            exit 1''}
+        exec ${scripts.${env.name}.submit-api}
     '')));
     entry-point = writeScriptBin "entry-point" ''
       #!${runtimeShell}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "9c6c9d57671310ae399f3babb3a2b419123d5a49",
-        "sha256": "17scxhb2jb11gcxjg7d6czqz8jh8ncrwqxv5bpk4k5ziwkyyva50",
+        "rev": "ce214b0e19942fee5c1dfcb086ff29cac086be31",
+        "sha256": "07qf5453vdbxq8sq4gmp7nl07q3kyqfjiyy2lfxkyi2cwg09l4cq",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/9c6c9d57671310ae399f3babb3a2b419123d5a49.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/ce214b0e19942fee5c1dfcb086ff29cac086be31.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
# Issue Number

Closes #63 
Closes #61 

# Overview

docker image had a hack to only allow you to run the image if the environment had a submitApiConfig in it. Now that submitApiConfig only contains logging, it will work with any environment. This removes that hack and update iohk-nix to latest to support MC4.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
