### PR TITLE
docker-images: set listen address to 0.0.0.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,9 @@ let
   dockerImages = let
     defaultConfig = rec {
       services.cardano-submit-api.socketPath = "/node-ipc/node.socket";
+      services.cardano-explorer-api.listenAddress = "0.0.0.0";
+      services.cardano-explorer-api.pgpassFile = "/configuration/pgpass";
+      services.cardano-submit-api.listenAddress = "0.0.0.0";
     };
     customConfig' = lib.mkMerge [ defaultConfig customConfig ];
   in pkgs.callPackage ./nix/docker.nix {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         max-file: "10"
 
   cardano-db-sync:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-3.0.0}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-3.1.0}
     environment:
       - NETWORK=${NETWORK:-mainnet}
       - POSTGRES_HOST=postgres
@@ -62,6 +62,7 @@ services:
       - postgres
       - cardano-db-sync
     environment:
+      - NETWORK=${NETWORK:-mainnet}
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
     secrets:
@@ -86,7 +87,7 @@ services:
     volumes:
       - node-ipc:/node-ipc
     ports:
-      - 8101:8101
+      - 8090:8090
     restart: on-failure
     logging:
       driver: "json-file"

--- a/nix/nixos/cardano-explorer-api-service.nix
+++ b/nix/nixos/cardano-explorer-api-service.nix
@@ -22,6 +22,10 @@ in {
         internal = true;
         type = lib.types.path;
       };
+      pgpassFile = lib.mkOption {
+        type = lib.types.path;
+        default = builtins.toFile "pgpass" "${cfg.postgres.socketdir}:${toString cfg.postgres.port}:${cfg.postgres.database}:${cfg.postgres.user}:*";
+      };
       package = lib.mkOption {
         type = lib.types.package;
         default = (import ../. {}).cardanoRestHaskellPackages.cardano-explorer-api.components.exes.cardano-explorer-api;
@@ -52,9 +56,8 @@ in {
   };
   config = lib.mkIf cfg.enable {
     services.cardano-explorer-api = {
-      pgpass = builtins.toFile "pgpass" "${cfg.postgres.socketdir}:${toString cfg.postgres.port}:${cfg.postgres.database}:${cfg.postgres.user}:*";
       script = pkgs.writeShellScript "cardano-explorer-api" ''
-        export PGPASSFILE=${cfg.pgpass}
+        export PGPASSFILE=${cfg.pgpassFile}
         exec ${cfg.package}/bin/cardano-explorer-api \
           --port ${toString cfg.port} \
           --listen-address ${cfg.listenAddress}


### PR DESCRIPTION
# Overview

Makes explorer-api work with NETWORK param so the listenAddress can be overridable. Sets default listen address for docker to 0.0.0.0.

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have ...


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
