### PR TITLE
Fix 'decodeTextAddress' not comprehending Shelley addresses.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-02-11T00:00:00Z
+index-state: 2020-07-15T00:00:00Z
 
 packages:
   rest-common
@@ -21,9 +21,6 @@ package cardano-submit-api
   ghc-options: -Wall -Werror -fwarn-redundant-constraints
 
 package cardano-db-sync
-  tests: False
-
-package cardano-shell
   tests: False
 
 package ouroboros-consensus
@@ -53,23 +50,16 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
-  --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
+  tag: 9ac5586149e40eee8ffdd95b9e3aea799055b3a4
+  --sha256: 0a8ikwbwq1b4d7y94dn3aj0frynjdahilgnzy2kyh5gdc6bq5053
   subdir: cardano-db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
-  --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
+  tag: 9ac5586149e40eee8ffdd95b9e3aea799055b3a4
+  --sha256: 0a8ikwbwq1b4d7y94dn3aj0frynjdahilgnzy2kyh5gdc6bq5053
   subdir: cardano-db-sync
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-shell
-  tag: bc3563c952d9f3635e1c76749b86b0a24f7e4b83
-  --sha256: 0c4f394h0wshcly6vcghvg5m6zd1i7s3a9kb1xlg7na4hn4y4a2v
-  subdir: cardano-shell
 
 source-repository-package
   type: git
@@ -386,16 +376,23 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 3258fdbb2ce8c56ca175401630aa71d75a4d6ab2
-  --sha256: 1la5nkw6nhfsc7izi28g39phfm4bnfza3srm49c16b9vgwqxl4wm
+  tag: d7a524dbfec3afc81ad478f237eb64bf40c66932
+  --sha256: 1pmdl16wyv3i05qq07sz4h34mdw7nxxi6smxvarghwsmv10afq5n
   subdir: cardano-api
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 3258fdbb2ce8c56ca175401630aa71d75a4d6ab2
-  --sha256: 1la5nkw6nhfsc7izi28g39phfm4bnfza3srm49c16b9vgwqxl4wm
+  tag: d7a524dbfec3afc81ad478f237eb64bf40c66932
+  --sha256: 1pmdl16wyv3i05qq07sz4h34mdw7nxxi6smxvarghwsmv10afq5n
   subdir: cardano-config
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: d7a524dbfec3afc81ad478f237eb64bf40c66932
+  --sha256: 1pmdl16wyv3i05qq07sz4h34mdw7nxxi6smxvarghwsmv10afq5n
+  subdir: cardano-node
 
 source-repository-package
   type: git

--- a/explorer-api/cardano-explorer-api.cabal
+++ b/explorer-api/cardano-explorer-api.cabal
@@ -64,9 +64,10 @@ library
   -- other-modules:
 
   build-depends:        base                            >= 4.12         && < 4.13
-                      , QuickCheck
                       , aeson
                       , base16-bytestring
+                      , base58-bytestring
+                      , bech32
                       , bytestring
                       , cardano-crypto-class
                       , cardano-db
@@ -83,10 +84,13 @@ library
                       , memory
                       , monad-logger
                       , mtl
+                      , ouroboros-consensus-shelley
                       , persistent
                       , persistent-postgresql
+                      , QuickCheck
                       , servant
                       , servant-server
+                      , shelley-spec-ledger
                       , text
                       , time
                       , transformers
@@ -108,6 +112,7 @@ test-suite unit
                         -Wincomplete-uni-patterns
 
   other-modules:        Test.Explorer.Web.ClientTypesSpec
+                        Test.Explorer.Web.Api.Legacy.UtilSpec
 
   build-depends:        base                            >= 4.12         && < 4.13
                       , aeson

--- a/explorer-api/cardano-explorer-api.cabal
+++ b/explorer-api/cardano-explorer-api.cabal
@@ -123,6 +123,8 @@ test-suite unit
                       , hspec
                       , hspec-hedgehog
 
+  build-tool-depends:   hspec-discover:hspec-discover
+
 executable cardano-explorer-api
   default-language:    Haskell2010
   main-is:             cardano-explorer-api.hs

--- a/explorer-api/cardano-explorer-api.cabal
+++ b/explorer-api/cardano-explorer-api.cabal
@@ -96,7 +96,7 @@ library
 test-suite unit
   default-language:     Haskell2010
   type:                 exitcode-stdio-1.0
-  main-is:              test.hs
+  main-is:              Main.hs
   hs-source-dirs:       test
 
   ghc-options:          -Wall
@@ -107,7 +107,7 @@ test-suite unit
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
 
-  other-modules:        Test.Explorer.Web.Property.Types
+  other-modules:        Test.Explorer.Web.ClientTypesSpec
 
   build-depends:        base                            >= 4.12         && < 4.13
                       , aeson
@@ -115,6 +115,8 @@ test-suite unit
                       , cardano-explorer-api
                       , cardano-ledger
                       , hedgehog
+                      , hspec
+                      , hspec-hedgehog
 
 executable cardano-explorer-api
   default-language:    Haskell2010

--- a/explorer-api/src/Explorer/Web/Api/Legacy/AddressSummary.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/AddressSummary.hs
@@ -8,8 +8,6 @@ module Explorer.Web.Api.Legacy.AddressSummary
   , queryAddressSummary
   ) where
 
-import Cardano.Chain.Common
-    ( Address, isRedeemAddress )
 import Cardano.Db
     ( EntityField (..), TxId, unValue3 )
 import Control.Monad.IO.Class
@@ -50,6 +48,7 @@ import Explorer.Web.Api.Legacy.Util
     , collapseTxGroup
     , decodeTextAddress
     , genesisDistributionTxHash
+    , isRedeemAddress
     , zipTxBrief
     )
 import Explorer.Web.ClientTypes
@@ -66,6 +65,8 @@ import Explorer.Web.Error
     ( ExplorerError (..) )
 import Explorer.Web.Query
     ( queryChainTip )
+import Shelley.Spec.Ledger.Address
+    ( Addr )
 
 import qualified Data.List as List
 
@@ -98,7 +99,7 @@ addressSummary (CAddress addrTxt) = runExceptT $ do
 
 -- -------------------------------------------------------------------------------------------------
 
-queryAddressSummary :: MonadIO m => Text -> Address -> SqlPersistT m (Either ExplorerError CAddressSummary)
+queryAddressSummary :: MonadIO m => Text -> Addr crypto -> SqlPersistT m (Either ExplorerError CAddressSummary)
 queryAddressSummary addrTxt addr = do
   chainTip <- queryChainTip
   if isRedeemAddress addr

--- a/explorer-api/src/Explorer/Web/Api/Legacy/BlockAddress.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/BlockAddress.hs
@@ -5,8 +5,6 @@ module Explorer.Web.Api.Legacy.BlockAddress
   ( blockAddress
   ) where
 
-import Cardano.Chain.Common
-    ( isRedeemAddress )
 import Cardano.Db
     ( EntityField (..), TxId, unValue3 )
 import Control.Monad.IO.Class
@@ -49,6 +47,7 @@ import Explorer.Web.Api.Legacy.Util
     ( bsBase16Encode
     , collapseTxGroup
     , decodeTextAddress
+    , isRedeemAddress
     , textBase16Decode
     , zipTxBrief
     )

--- a/explorer-api/src/Explorer/Web/ClientTypes.hs
+++ b/explorer-api/src/Explorer/Web/ClientTypes.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/explorer-api/src/Explorer/Web/Error.hs
+++ b/explorer-api/src/Explorer/Web/Error.hs
@@ -27,7 +27,7 @@ import qualified Formatting.Buildable
 data ExplorerError
   = Internal Text  -- Stupid error constructor from the old code base.
   | EELookupFail !LookupFail
-  deriving (Generic)
+  deriving (Generic, Show)
 
 instance Buildable ExplorerError where
   build ee =

--- a/explorer-api/test/Main.hs
+++ b/explorer-api/test/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/explorer-api/test/Test/Explorer/Web/Api/Legacy/UtilSpec.hs
+++ b/explorer-api/test/Test/Explorer/Web/Api/Legacy/UtilSpec.hs
@@ -63,3 +63,14 @@ spec = do
             decodeTextAddress
                 "addr1g8ejymax5dh6srcj3sehf6lt0czdj9uklffzhc3fqgglnlf2pcqqc69etp"
                 `shouldSatisfy` isRight
+
+        it "✓ can decode Base16 Byron address" $ do
+            decodeTextAddress
+                "82d818582183581c4ad651d1c6afe6b3483eac69ab9\
+                \6575519376f136f024c35e5d27071a0001a453d0d11"
+                `shouldSatisfy` isRight
+
+        it "✓ can decode Base16 Shelley address" $ do
+            decodeTextAddress
+                "6079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65"
+                `shouldSatisfy` isRight

--- a/explorer-api/test/Test/Explorer/Web/Api/Legacy/UtilSpec.hs
+++ b/explorer-api/test/Test/Explorer/Web/Api/Legacy/UtilSpec.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Explorer.Web.Api.Legacy.UtilSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Data.Either
+    ( isLeft, isRight )
+import Explorer.Web.Api.Legacy.Util
+    ( decodeTextAddress )
+import Test.Hspec
+    ( Spec, describe, it, shouldSatisfy )
+
+spec :: Spec
+spec = do
+    describe "decodeTextAddress" $ do
+        it "x cannot decode arbitrary unicode" $ do
+            decodeTextAddress
+                "💩"
+                `shouldSatisfy` isLeft
+
+        it "x cannot decode gibberish base58" $ do
+            decodeTextAddress
+                "FpqXJLkgVhRTYkf5F7mh3q6bAv5hWYjhSV1gekjEJE8XFeZSganv"
+                `shouldSatisfy` isLeft
+
+        it "x cannot decode Jörmungandr address" $ do
+            decodeTextAddress
+                "addr1qdaa2wrvxxkrrwnsw6zk2qx0ymu96354hq83s0r6203l9pqe6677z5t3m7d"
+                `shouldSatisfy` isLeft
+
+        it "✓ can decode Base58 Byron address (Legacy Mainnet)" $ do
+            decodeTextAddress
+                "DdzFFzCqrhstkaXBhux3ALL9wqvP3Nkz8QE5qKwFbqkmTL6zyKpc\
+                \FpqXJLkgVhRTYkf5F7mh3q6bAv5hWYjhSV1gekjEJE8XFeZSganv"
+                `shouldSatisfy` isRight
+
+        it "✓ can decode Base58 Byron address (Legacy Testnet)" $ do
+            decodeTextAddress
+                "37btjrVyb4KEgoGCHJ7XFaJRLBRiVuvcrQWPpp4HeaxdTxhKwQjXHNKL4\
+                \3NhXaQNa862BmxSFXZFKqPqbxRc3kCUeTRMwjJevFeCKokBG7A7num5Wh"
+                `shouldSatisfy` isRight
+
+        it "✓ can decode Base58 Byron address (Icarus)" $ do
+            decodeTextAddress
+                "Ae2tdPwUPEZ4Gs4s2recjNjQHBKfuBTkeuqbHJJrC6CuyjGyUD44cCTq4sJ"
+                `shouldSatisfy` isRight
+
+        it "✓ can decode Bech32 Shelley address (basic)" $ do
+            decodeTextAddress
+                "addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w"
+                `shouldSatisfy` isRight
+
+        it "✓ can decode Bech32 Shelley address (stake by value)" $ do
+            decodeTextAddress
+                "addr1qrejymax5dh6srcj3sehf6lt0czdj9uklffzhc3fqgglnl\
+                \0nyfh6dgm04q839rpnwn47klsymyted7jj903zjqs3l87sutspf7"
+                `shouldSatisfy` isRight
+
+        it "✓ can decode Bech32 Shelley address (pointer)" $ do
+            decodeTextAddress
+                "addr1g8ejymax5dh6srcj3sehf6lt0czdj9uklffzhc3fqgglnlf2pcqqc69etp"
+                `shouldSatisfy` isRight

--- a/explorer-api/test/Test/Explorer/Web/ClientTypesSpec.hs
+++ b/explorer-api/test/Test/Explorer/Web/ClientTypesSpec.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
-
-module Test.Explorer.Web.Property.Types
-  ( tests
+module Test.Explorer.Web.ClientTypesSpec
+  ( spec
   ) where
 
 import Cardano.Chain.Common
@@ -13,15 +11,18 @@ import Data.Word
 import Explorer.Web.ClientTypes
     ( adaToCCoin, cCoinToAda )
 import Hedgehog
-    ( Gen, Property, discover )
+    ( Gen, PropertyT )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.Hspec.Hedgehog
+    ( hedgehog )
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-prop_roundtrip_ada_to_ccoin :: Property
-prop_roundtrip_ada_to_ccoin =
-  H.withTests 1000 . H.property $ do
+prop_roundtrip_ada_to_ccoin :: PropertyT IO ()
+prop_roundtrip_ada_to_ccoin = do
     ada <- H.forAll genAda
     H.tripping ada adaToCCoin (Just . cCoinToAda)
 
@@ -39,5 +40,6 @@ genAda =
 
 -- -----------------------------------------------------------------------------
 
-tests :: IO Bool
-tests = H.checkParallel $$discover
+spec :: Spec
+spec = describe "ClientTypesSpec" $ do
+    it "adaToCCoin . cCoinToAda" $ hedgehog prop_roundtrip_ada_to_ccoin

--- a/explorer-api/test/test.hs
+++ b/explorer-api/test/test.hs
@@ -1,9 +1,0 @@
-import           Hedgehog.Main (defaultMain)
-
-import qualified Test.Explorer.Web.Property.Types
-
-main :: IO ()
-main =
-  defaultMain
-    [ Test.Explorer.Web.Property.Types.tests
-    ]

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "32baaac4d7858ae3349c1f6d1452371f998c7f49",
-        "sha256": "0g0jh0jwips3qyxs7rb1d4qvqs6rralnq318x5x2wvy1mkzvxvlg",
+        "rev": "a904d403d869a8a73b3c77f812f84682f37df4e9",
+        "sha256": "1pmj6zkvaq4zaf7pniin1737w9s5hlrcx996qay1wkbz31cfki3b",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/32baaac4d7858ae3349c1f6d1452371f998c7f49.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/a904d403d869a8a73b3c77f812f84682f37df4e9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -58,7 +58,7 @@ packages:
         - cborg
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: 3258fdbb2ce8c56ca175401630aa71d75a4d6ab2
+    commit: ba0f96b1a9fc9232ed211e57835fd5018093069d
     subdirs:
       - cardano-api
       - cardano-config
@@ -102,7 +102,7 @@ packages:
     commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 9dc2eab127849ad7b7cada13c6681dda540a88fe
+    commit: 183a70c001587d9b1977541deae28c3e44713907
     subdirs:
       - byron/chain/executable-spec
       - byron/crypto

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -58,7 +58,7 @@ packages:
         - cborg
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: ba0f96b1a9fc9232ed211e57835fd5018093069d
+    commit: d7a524dbfec3afc81ad478f237eb64bf40c66932
     subdirs:
       - cardano-api
       - cardano-config

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-db-sync
-    commit: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
+    commit: 9ac5586149e40eee8ffdd95b9e3aea799055b3a4
     subdirs:
       - cardano-db
       - cardano-db-sync

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,6 +18,8 @@ extra-deps:
   - git: https://github.com/input-output-hk/cardano-crypto
     commit: 2547ad1e80aeabca2899951601079408becbc92c
 
+  - hspec-hedgehog-0.0.1.2
+
 ghc-options:
   cardano-explorer-api: -Wall -Werror -fwarn-redundant-constraints
   cardano-submit-api:   -Wall -Werror -fwarn-redundant-constraints
@@ -30,3 +32,7 @@ flags:
   # This still requires the host system to have the 'standard' libsodium installed.
   cardano-crypto-praos:
     external-libsodium-vrf: false
+
+# generate files required by weeder.
+# see https://github.com/ndmitchell/weeder/issues/53
+ghc-options: {"$locals": -ddump-to-file -ddump-hi}


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#75 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- cb2d0c75cc55cc06eebecee92d478bd836f1f6a2
  :round_pushpin: **fix wrong / inconsistent dependencies in the stack snapshot**
  
- 5208a5d7a8d95021b34b92911a9d61c53e8f8ecc
  :round_pushpin: **use hspec as a test runner for explorer-api unit tests**
  
- 712ee296abbbd34324710540e92e13700a06295e
  :round_pushpin: **add unit tests showing how 'decodeTextAddress' should behave**
  
- 03e894dc6d8506f89878d7d0ed8496a9cc3f49c8
  :round_pushpin: **make sure 'decodeTextAddress' can comprehend both base58 and bech32, and decode Shelley addresses.**
  
- 06f0405cd9ef3c50bb18316ae5415ac6fbba9e80
  :round_pushpin: **allow base16 as input encoding as well for decoding addresses**


# Comments

<!-- Additional comments or screenshots to attach if any -->

```
Test.Explorer.Web.Api.Legacy.Util
  decodeTextAddress
    x cannot decode arbitrary unicode
    x cannot decode gibberish base58
    x cannot decode Jörmungandr address
    ✓ can decode Base58 Byron address (Legacy Mainnet)
    ✓ can decode Base58 Byron address (Legacy Testnet)
    ✓ can decode Base58 Byron address (Icarus)
    ✓ can decode Bech32 Shelley address (basic)
    ✓ can decode Bech32 Shelley address (stake by value)
    ✓ can decode Bech32 Shelley address (pointer)
Test.Explorer.Web.ClientTypes
  ClientTypesSpec
    adaToCCoin . cCoinToAda

Finished in 0.0046 seconds
10 examples, 0 failures
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
