### PR TITLE
revert bumping dependency to unreleased version of cardano-db-sync

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-07-15T00:00:00Z
+index-state: 2020-02-11T00:00:00Z
 
 packages:
   rest-common
@@ -21,6 +21,9 @@ package cardano-submit-api
   ghc-options: -Wall -Werror -fwarn-redundant-constraints
 
 package cardano-db-sync
+  tests: False
+
+package cardano-shell
   tests: False
 
 package ouroboros-consensus
@@ -50,16 +53,23 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 9ac5586149e40eee8ffdd95b9e3aea799055b3a4
-  --sha256: 0a8ikwbwq1b4d7y94dn3aj0frynjdahilgnzy2kyh5gdc6bq5053
+  tag: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
+  --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
   subdir: cardano-db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 9ac5586149e40eee8ffdd95b9e3aea799055b3a4
-  --sha256: 0a8ikwbwq1b4d7y94dn3aj0frynjdahilgnzy2kyh5gdc6bq5053
+  tag: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
+  --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
   subdir: cardano-db-sync
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-shell
+  tag: bc3563c952d9f3635e1c76749b86b0a24f7e4b83
+  --sha256: 0c4f394h0wshcly6vcghvg5m6zd1i7s3a9kb1xlg7na4hn4y4a2v
+  subdir: cardano-shell
 
 source-repository-package
   type: git
@@ -376,23 +386,16 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: d7a524dbfec3afc81ad478f237eb64bf40c66932
-  --sha256: 1pmdl16wyv3i05qq07sz4h34mdw7nxxi6smxvarghwsmv10afq5n
+  tag: ba0f96b1a9fc9232ed211e57835fd5018093069d
+  --sha256: 1rj7rpr3qqqwdx00zsfg283jflndnr9q5arxf5fiqrrqms40p7sk
   subdir: cardano-api
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: d7a524dbfec3afc81ad478f237eb64bf40c66932
-  --sha256: 1pmdl16wyv3i05qq07sz4h34mdw7nxxi6smxvarghwsmv10afq5n
+  tag: ba0f96b1a9fc9232ed211e57835fd5018093069d
+  --sha256: 1rj7rpr3qqqwdx00zsfg283jflndnr9q5arxf5fiqrrqms40p7sk
   subdir: cardano-config
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-node
-  tag: d7a524dbfec3afc81ad478f237eb64bf40c66932
-  --sha256: 1pmdl16wyv3i05qq07sz4h34mdw7nxxi6smxvarghwsmv10afq5n
-  subdir: cardano-node
 
 source-repository-package
   type: git

--- a/explorer-api/cardano-explorer-api.cabal
+++ b/explorer-api/cardano-explorer-api.cabal
@@ -121,7 +121,6 @@ test-suite unit
                       , cardano-ledger
                       , hedgehog
                       , hspec
-                      , hspec-hedgehog
 
   build-tool-depends:   hspec-discover:hspec-discover
 

--- a/explorer-api/test/Test/Explorer/Web/ClientTypesSpec.hs
+++ b/explorer-api/test/Test/Explorer/Web/ClientTypesSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Test.Explorer.Web.ClientTypesSpec
   ( spec
   ) where
@@ -13,9 +15,7 @@ import Explorer.Web.ClientTypes
 import Hedgehog
     ( Gen, PropertyT )
 import Test.Hspec
-    ( Spec, describe, it )
-import Test.Hspec.Hedgehog
-    ( hedgehog )
+    ( Spec, describe, it, shouldBe )
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
@@ -42,4 +42,10 @@ genAda =
 
 spec :: Spec
 spec = describe "ClientTypesSpec" $ do
-    it "adaToCCoin . cCoinToAda" $ hedgehog prop_roundtrip_ada_to_ccoin
+    it "properties" $ do
+        result <- H.checkParallel $ H.Group "ClientTypesSpec"
+            [ ( "adaToCCoin . cCoinToAda"
+              , H.property prop_roundtrip_ada_to_ccoin
+              )
+            ]
+        result `shouldBe` True

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -58,7 +58,7 @@ packages:
         - cborg
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: d7a524dbfec3afc81ad478f237eb64bf40c66932
+    commit: ba0f96b1a9fc9232ed211e57835fd5018093069d
     subdirs:
       - cardano-api
       - cardano-config

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,15 +10,13 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-db-sync
-    commit: 9ac5586149e40eee8ffdd95b9e3aea799055b3a4
+    commit: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
     subdirs:
       - cardano-db
       - cardano-db-sync
 
   - git: https://github.com/input-output-hk/cardano-crypto
     commit: 2547ad1e80aeabca2899951601079408becbc92c
-
-  - hspec-hedgehog-0.0.1.2
 
 ghc-options:
   cardano-explorer-api: -Wall -Werror -fwarn-redundant-constraints


### PR DESCRIPTION


# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have removed hspec-hedgehog dependency and reverted the bump of cardano-db-sync and removal of cardano-shell.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
