### PR TITLE
Update cardano-db-sync

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -399,6 +399,13 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/cardano-node
+  tag: ba0f96b1a9fc9232ed211e57835fd5018093069d
+  --sha256: 1rj7rpr3qqqwdx00zsfg283jflndnr9q5arxf5fiqrrqms40p7sk
+  subdir: cardano-node
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/bech32.git
   tag: e8d546c154b5b0502f80b76a02bc023b09778918
   --sha256: 0vvja8ada9rmqm1g6w1kkz2jl9spllbj6nfs75dpnmkgby7278f2

--- a/cabal.project
+++ b/cabal.project
@@ -54,14 +54,14 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
   tag: eb58508e3fe182976f1d5d69a1fdc8f393029eaf
-  --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
+  --sha256: 0ri7xb3clf5bnpd2kcmb60zm56306chmy9jgbmh9jh36qnzfwaxx
   subdir: cardano-db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
   tag: eb58508e3fe182976f1d5d69a1fdc8f393029eaf
-  --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
+  --sha256: 0ri7xb3clf5bnpd2kcmb60zm56306chmy9jgbmh9jh36qnzfwaxx
   subdir: cardano-db-sync
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -53,14 +53,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
+  tag: eb58508e3fe182976f1d5d69a1fdc8f393029eaf
   --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
   subdir: cardano-db
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
+  tag: eb58508e3fe182976f1d5d69a1fdc8f393029eaf
   --sha256: 0yyqz0k4f3ma4w0wjxsjlnjikx9cha9k3cwz3ry6bar63a2s5n7g
   subdir: cardano-db-sync
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/input-output-hk/cardano-db-sync
-    commit: 7f9959c9a0746d44d331cffcf7abb0ef4f4fb948
+    commit: eb58508e3fe182976f1d5d69a1fdc8f393029eaf
     subdirs:
       - cardano-db
       - cardano-db-sync


### PR DESCRIPTION
- Cardano-db-sync has been updated, renaming "block.slot_leader" to
"block.slot_leader_id" in the database schema. This commit bumps the
version of cardano-db-sync used so that cardano-explorer-api interacts
correctly with the database.