### PR TITLE
source diffrent from cardano-db-sync:6.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.5"
 services:
   postgres:
     image: postgres:11.5-alpine
-    command: postgres -c 'max_pred_locks_per_transaction=128' -c 'max_locks_per_transaction=128'
     environment:
       - POSTGRES_LOGGING=true
       - POSTGRES_DB_FILE=/run/secrets/postgres_db
@@ -51,6 +50,7 @@ services:
       - postgres_user
       - postgres_db
     volumes:
+      - db-sync-data:/var/lib/cdbsync
       - node-ipc:/node-ipc
     restart: on-failure
     logging:
@@ -107,6 +107,7 @@ secrets:
     file: ./config/postgres_user
 
 volumes:
+  db-sync-data:
   postgres:
   node-db:
   node-ipc:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

it's docker-compose.yaml is different from cardano-db-sync
[https://github.com/input-output-hk/cardano-db-sync/commit/6187081a7ea66954c86094578bd37e01bca8aaec#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3](https://github.com/input-output-hk/cardano-db-sync/commit/6187081a7ea66954c86094578bd37e01bca8aaec#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3)

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
