### PR TITLE
fix: add Docker volume to persist `cardano-db-sync` internal state

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - postgres_user
       - postgres_db
     volumes:
+      - db-sync-data:/var/lib/cdbsync
       - node-ipc:/node-ipc
     restart: on-failure
     logging:
@@ -107,6 +108,7 @@ secrets:
     file: ./config/postgres_user
 
 volumes:
+  db-sync-data:
   postgres:
   node-db:
   node-ipc:


### PR DESCRIPTION
# Issue Number
https://github.com/input-output-hk/cardano-db-sync/issues/397#issuecomment-725795718
