### PR TITLE
Revert added feature in 3.0.0 causing issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
         max-file: "10"
 
   cardano-explorer-api:
-    image: inputoutput/cardano-explorer-api:${CARDANO_EXPLORER_API_VERSION:-3.1.0}
+    image: inputoutput/cardano-explorer-api:${CARDANO_EXPLORER_API_VERSION:-3.1.1}
     depends_on:
       - postgres
       - cardano-db-sync
@@ -83,7 +83,7 @@ services:
         max-file: "10"
 
   cardano-submit-api:
-    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-3.1.0}
+    image: inputoutput/cardano-submit-api:${CARDANO_SUBMIT_API_VERSION:-3.1.1}
     environment:
       - NETWORK=${NETWORK:-mainnet}
     depends_on:

--- a/explorer-api/CHANGELOG.md
+++ b/explorer-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1 -- December 2020
+
+* ø (patch in submit-api).
+
 ## 3.1.0 -- December 2020
 
 * Fix an internal error with 'InnerJoin' requests on block's transaction summary.

--- a/explorer-api/cardano-explorer-api.cabal
+++ b/explorer-api/cardano-explorer-api.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-explorer-api
-version:                3.1.0
+version:                3.1.1
 synopsis:               A Block Explorer for the Cardano network
 description:
 homepage:               https://github.com/input-output-hk/cardano-explorer

--- a/rest-common/cardano-rest-common.cabal
+++ b/rest-common/cardano-rest-common.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-rest-common
-version:                3.1.0
+version:                3.1.1
 synopsis:               A Block Explorer for the Cardano network
 description:
 homepage:               https://github.com/input-output-hk/cardano-explorer

--- a/submit-api/CHANGELOG.md
+++ b/submit-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.1.1 -- December 2020 
+
+* Revert the MIME-type `encoding` addition from 3.1.0. Turns out there's a bug with an underlying dependency 
+  causing the feature to misbehave. Removing for now. Will rework later if time allows.
+
 ## 3.1.0 -- December 2020
 
 * Allow clients to define an extra outer-encoding for the submit endpoint using a MIME-type parameter `encoding`. 

--- a/submit-api/cardano-submit-api.cabal
+++ b/submit-api/cardano-submit-api.cabal
@@ -52,8 +52,7 @@ library
   build-depends:        base                            >= 4.12         && < 4.13
                       , aeson
                       , async
-                      , base16
-                      , base64
+                      , base16-bytestring
                       , bytestring
                       , cardano-api
                       , cardano-binary

--- a/submit-api/cardano-submit-api.cabal
+++ b/submit-api/cardano-submit-api.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-submit-api
-version:                3.1.0
+version:                3.1.1
 synopsis:               A web server that allows transactions to be POSTed to the cardano chain
 description:
 homepage:               https://github.com/input-output-hk/cardano-explorer

--- a/submit-api/swagger.yaml
+++ b/submit-api/swagger.yaml
@@ -20,13 +20,13 @@ paths:
     post:
       operationId: postTransaction
       summary: Submit Tx
-      description: Submit an already serialized transaction to the network. Use an extra 'encoding' MIME parameter to send bytestring encoded in `base16` or `base64`.
+      description: Submit an already serialized transaction to the network.
       parameters:
         - in: header
           name: Content-Type
           required: true
           type: string
-          enum: ["application/cbor", "application/cbor; encoding=base16", "application/cbor; encoding=base64"]
+          enum: ["application/cbor"]
 
       x-code-samples:
         - lang: "Shell"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

Fixes #109 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 0c3d0fd133ec321b70fffa28754265aec4b94e2f
  :round_pushpin: **Revert "Allow clients to specify an outer encoding for submit-api"**
    This reverts commit 40c94e362d5b76e89ba9530f8fcb0f49b1b21ad2.
  There's apparently a bug in Servant which does not report the actual
  media-type set by client requests, but does report the first match
  from the declared API. Pattern-matching on the media-type therefore
  does not work and lead to undesired behavior.

  This feature was non-essential to the last upgrade but done as a
  "gesture" while going through open issues on Github. Thus I am
  simply reverting this commit for now and we'll consider re-adding
  this in a proper way later.

- dd1a6eadd5e18a84f28150bad7bcce9782db5789
  :round_pushpin: **bump versions to 3.1.1 and write CHANGELOG(s).**

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
