### PR TITLE
Update queryBlocksTxs error message

### DIFF
--- a/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
+++ b/explorer-api/src/Explorer/Web/Api/Legacy/BlocksTxs.hs
@@ -91,7 +91,7 @@ queryBlocksTxs blkHash _limitNum _offsetNum  = do
             -- offset offsetNum
             pure (tx ^. TxId, tx ^. TxHash, blk ^. BlockTime)
     case map unValue3 res of
-      [] -> pure $ Left (Internal "No block found")
+      [] -> pure $ Left (Internal "No transactions found in block")
       xs -> Right <$> queryCTxBriefs xs
 
 queryCTxBriefs :: MonadIO m => [(TxId, ByteString, UTCTime)] -> SqlPersistT m [CTxBrief]


### PR DESCRIPTION
Updated the error message returned by queryBlocksTxs to more
accurately reflect that no transactions were found for the
input block. The old message suggested that the block itself
does not exist, which is not necessarily the case. 

# Issue Number

#111

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- Updated the message returned by queryBlocksTxs in cases where the query returns no results to be a bit more clear.


# Comments

cc @melmccann who observed this issue

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
